### PR TITLE
Enable local kb upload option to external server and add chunks only and with embeddings options for flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.5.0] - 2025-12-09
+
+### Changed
+- **Flag Names**: Renamed `--embeddings` to `--with-embeddings` and added `--chunks-only` flag for clarity
+- **Embedding Model**: Upgraded from `text-embedding-ada-002` to `text-embedding-3-large` (3072 dimensions)
+- **Payload Structure**: Enhanced to support chunks array with `hasEmbeddings` flag for external server integration
+- **Upload Command**: Added `--chunks-only` and `--with-embeddings` flags to upload command
+- **Search URL**: `EXTERNAL_KB_SEARCH_URL` is now required (no auto-generation) for external server search operations
+
+### Added
+- **Chunks Support**: `--chunks-only` flag to create chunks locally (useful with external server)
+- **Processing Modes Table**: Added comprehensive table in README showing all mode/flag combinations
+- **Early Validation**: OpenAI API key and external server validation before processing starts
+- **Validation Utilities**: Centralized validation functions in `validation-utils.js` to eliminate code duplication
+- **Server Health Check**: External server validation now includes `/health` endpoint check before processing
+- **Separate Search URL**: `EXTERNAL_KB_SEARCH_URL` environment variable for independent search endpoint configuration
+
+### Fixed
+- Improved error handling for invalid API keys and server authentication failures
+- Better error messages with actionable guidance
+- Removed duplicate error logging in validation flow
+- Search command now requires explicit `EXTERNAL_KB_SEARCH_URL` when using external server
+
 ## [1.4.0] - 2025-01-06
 
 ### Added

--- a/external-server-service.js
+++ b/external-server-service.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { EXTERNAL_SERVER_CONFIG, buildPayload, validateConfig, isExternalServerEnabled } = require('./external-server-config');
+const { EXTERNAL_SERVER_CONFIG, buildPayload, buildEmbeddingsPayload, validateConfig, isExternalServerEnabled } = require('./external-server-config');
 
 class ExternalServerService {
   constructor(config = {}) {
@@ -27,10 +27,14 @@ class ExternalServerService {
     // Build payload according to your specification
     const payload = buildPayload(document, options);
     
-    console.log(`📤 Sending to external server: ${document.relativePath}`);
-    console.log(`   Size: ${document.size} bytes`);
-    console.log(`   Language: ${document.metadata.language}`);
-    console.log(`   ⏳ Processing...`);
+    // Only show detailed logs for non-validation requests
+    const isValidationRequest = document.title === '__validation_test__';
+    if (!isValidationRequest) {
+      console.log(`📤 Sending to external server: ${document.relativePath}`);
+      console.log(`   Size: ${document.size} bytes`);
+      console.log(`   Language: ${document.metadata.language}`);
+      console.log(`   ⏳ Processing...`);
+    }
 
     // Retry logic
     let lastError;
@@ -38,16 +42,28 @@ class ExternalServerService {
       try {
         const response = await this.makeRequest(payload);
         
-        console.log(`   ✅ Sent successfully (${response.status} ${response.statusText})`);
+        if (!isValidationRequest) {
+          console.log(`   ✅ Sent successfully (${response.status} ${response.statusText})`);
+        }
         
         return await response.json();
         
       } catch (error) {
         lastError = error;
-        console.warn(`⚠️  Attempt ${attempt}/${this.config.retry.attempts} failed: ${error.message}`);
+        
+        // Check for authentication errors - stop immediately, don't retry
+        if (error.message.includes('401') || error.message.includes('403') || error.message.includes('Unauthorized')) {
+          throw new Error(`External server authentication failed: ${error.message}`);
+        }
+        
+        if (!isValidationRequest) {
+          console.warn(`⚠️  Attempt ${attempt}/${this.config.retry.attempts} failed: ${error.message}`);
+        }
         
         if (attempt < this.config.retry.attempts) {
-          console.log(`   🔄 Retrying in ${this.config.retry.delay}ms...`);
+          if (!isValidationRequest) {
+            console.log(`   🔄 Retrying in ${this.config.retry.delay}ms...`);
+          }
           await this.sleep(this.config.retry.delay);
         }
       }
@@ -78,6 +94,10 @@ class ExternalServerService {
       
       if (!response.ok) {
         const errorText = await response.text().catch(() => 'Unknown error');
+        // Provide clearer error messages for auth failures
+        if (response.status === 401 || response.status === 403) {
+          throw new Error(`HTTP ${response.status} Unauthorized: ${errorText || 'Invalid or missing API key'}`);
+        }
         throw new Error(`HTTP ${response.status}: ${errorText}`);
       }
       
@@ -92,6 +112,54 @@ class ExternalServerService {
       
       throw error;
     }
+  }
+
+  async sendEmbeddings(document, options = {}) {
+    // Validate embeddings exist
+    if (!document.chunks || document.chunks.length === 0) {
+      throw new Error('Document must have chunks to send embeddings');
+    }
+
+    const hasEmbeddings = document.chunks.some(chunk => chunk.embedding);
+    if (!hasEmbeddings) {
+      throw new Error('Document chunks must have embeddings to send');
+    }
+
+    // Build embeddings payload
+    const payload = buildEmbeddingsPayload(document, options);
+    
+    console.log(`📤 Sending embeddings to external server: ${document.relativePath}`);
+    console.log(`   Chunks: ${document.chunks.length}`);
+    console.log(`   ⏳ Processing...`);
+
+    // Retry logic
+    let lastError;
+    for (let attempt = 1; attempt <= this.config.retry.attempts; attempt++) {
+      try {
+        const response = await this.makeRequest(payload);
+        
+        console.log(`   ✅ Sent successfully (${response.status} ${response.statusText})`);
+        
+        return await response.json();
+        
+      } catch (error) {
+        lastError = error;
+        
+        // Check for authentication errors - stop immediately, don't retry
+        if (error.message.includes('401') || error.message.includes('403') || error.message.includes('Unauthorized')) {
+          throw new Error(`External server authentication failed: ${error.message}`);
+        }
+        
+        console.warn(`⚠️  Attempt ${attempt}/${this.config.retry.attempts} failed: ${error.message}`);
+        
+        if (attempt < this.config.retry.attempts) {
+          console.log(`   🔄 Retrying in ${this.config.retry.delay}ms...`);
+          await this.sleep(this.config.retry.delay);
+        }
+      }
+    }
+    
+    throw new Error(`External server failed after ${this.config.retry.attempts} attempts: ${lastError.message}`);
   }
 
   async sendBatch(documents, options = {}) {
@@ -186,6 +254,108 @@ class ExternalServerService {
       timeout: this.config.timeout,
       payload: this.config.payload
     };
+  }
+
+  /**
+   * Validate external server availability and authentication
+   * 1. Checks /health endpoint to verify server is running
+   * 2. Tests /api/knowledge/search endpoint to verify auth
+   * Throws error if server unavailable or auth fails
+   */
+  async validateServer() {
+    const baseUrl = this.config.url;
+    if (!baseUrl) {
+      throw new Error('EXTERNAL_KB_URL is not configured');
+    }
+
+    // Extract base URL (remove /items, /search, /process, etc.)
+    let healthUrl = baseUrl;
+    if (healthUrl.endsWith('/items') || healthUrl.endsWith('/search') || healthUrl.endsWith('/process')) {
+      // Remove the endpoint path to get base URL
+      const urlObj = new URL(healthUrl);
+      healthUrl = `${urlObj.protocol}//${urlObj.host}`;
+    }
+    // Ensure /health endpoint
+    healthUrl = healthUrl.endsWith('/') ? healthUrl + 'health' : healthUrl + '/health';
+
+    console.log('🔍 Validating external server...');
+    
+    // Step 1: Check server health
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.config.timeout);
+      
+      const healthResponse = await fetch(healthUrl, {
+        method: 'GET',
+        headers: {
+          'User-Agent': 'src-to-kb/1.5.0'
+        },
+        signal: controller.signal
+      });
+      
+      clearTimeout(timeoutId);
+
+      if (!healthResponse.ok) {
+        throw new Error(`Server health check failed: ${healthResponse.status} ${healthResponse.statusText}`);
+      }
+      console.log('   ✅ Server is available');
+    } catch (error) {
+      if (error.name === 'AbortError' || error.message.includes('timeout')) {
+        throw new Error(`Server is not responding at ${baseUrl}\n   → Please check if the server is running\n   → Verify the EXTERNAL_KB_URL is correct`);
+      }
+      if (error.message.includes('ECONNREFUSED') || error.message.includes('ENOTFOUND') || error.message.includes('fetch failed')) {
+        throw new Error(`Cannot connect to server at ${baseUrl}\n   → Please check if the server is running\n   → Verify the EXTERNAL_KB_URL path is correct\n   → Check network connectivity`);
+      }
+      throw new Error(`Server health check failed: ${error.message}\n   → Please verify the server is running at ${baseUrl}\n   → Check the EXTERNAL_KB_URL path is correct`);
+    }
+
+    // Step 2: Test authentication with search endpoint
+    try {
+      const searchUrl = this.config.searchUrl;
+      if (!searchUrl) {
+        throw new Error('EXTERNAL_KB_SEARCH_URL is required when using external server. Please set EXTERNAL_KB_SEARCH_URL environment variable.');
+      }
+
+      const headers = { ...this.config.headers };
+      if (process.env.EXTERNAL_KB_API_KEY) {
+        headers['x-api-key'] = process.env.EXTERNAL_KB_API_KEY;
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.config.timeout);
+      
+      const testResponse = await fetch(searchUrl, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify({ query: '__validation_test__' }),
+        signal: controller.signal
+      });
+      
+      clearTimeout(timeoutId);
+
+      if (testResponse.status === 401 || testResponse.status === 403) {
+        throw new Error(`HTTP ${testResponse.status} Unauthorized: Invalid or missing API key`);
+      }
+
+      if (!testResponse.ok) {
+        // For non-auth errors, we still consider validation passed (server is up and auth works)
+        // The actual search might fail, but that's okay for validation
+        console.log('   ✅ Authentication validated');
+      } else {
+        console.log('   ✅ Authentication validated');
+      }
+    } catch (error) {
+      if (error.message.includes('401') || error.message.includes('403') || error.message.includes('Unauthorized')) {
+        throw new Error(`External server authentication failed\n   → Please check your EXTERNAL_KB_API_KEY environment variable\n   → Verify the API key is valid and has proper permissions`);
+      }
+      if (error.name === 'AbortError' || error.message.includes('timeout')) {
+        throw new Error(`Server request timeout at ${baseUrl}\n   → Please check if the server is accessible\n   → Verify network connectivity`);
+      }
+      // For other errors, we still consider it a validation failure
+      throw new Error(`External server validation failed: ${error.message}\n   → Please verify the server is running\n   → Check EXTERNAL_KB_URL and EXTERNAL_KB_API_KEY settings`);
+    }
+
+    console.log('✅ External server validated successfully\n');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@vezlo/src-to-kb",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Convert source code repositories into searchable knowledge bases with MCP support for Claude and Cursor",
   "main": "kb-generator.js",
   "type": "commonjs",
   "bin": {
     "src-to-kb": "./kb-generator.js",
     "src-to-kb-search": "./search.js",
+    "src-to-kb-upload": "./upload.js",
     "src-to-kb-mcp": "./mcp-server.mjs",
     "src-to-kb-mcp-install": "./install-mcp.js",
     "src-to-kb-api": "./api-server.js"

--- a/upload.js
+++ b/upload.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { ExternalServerService } = require('./external-server-service');
+const { isExternalServerEnabled } = require('./external-server-config');
+const { validateExternalServer: validateExternalServerUtil } = require('./validation-utils');
+
+class KnowledgeBaseUploader {
+  constructor(kbPath = './knowledge-base') {
+    this.kbPath = kbPath;
+    this.documents = new Map();
+    this.chunks = new Map();
+    this.embeddings = new Map();
+    
+    // Check if external server URL is provided
+    if (!isExternalServerEnabled()) {
+      throw new Error('EXTERNAL_KB_URL environment variable is required for upload');
+    }
+    
+    this.externalServer = new ExternalServerService();
+    const extConfig = this.externalServer.getConfig();
+    console.log('🌐 External server enabled');
+    console.log(`   URL: ${extConfig.url}`);
+    if (process.env.EXTERNAL_KB_API_KEY) {
+      console.log(`   API Key: ${'*'.repeat(process.env.EXTERNAL_KB_API_KEY.length - 4)}${process.env.EXTERNAL_KB_API_KEY.slice(-4)}`);
+    }
+    this.serverValidated = false;
+  }
+
+  /**
+   * Validate external server availability and authentication
+   * Called before upload to fail fast if server is unavailable
+   */
+  async validateExternalServer() {
+    if (this.serverValidated) {
+      return;
+    }
+
+    await validateExternalServerUtil(this.externalServer, { cacheResult: true });
+    this.serverValidated = true;
+  }
+
+  loadKnowledgeBase() {
+    console.log(`\n📚 Loading knowledge base from: ${this.kbPath}\n`);
+
+    // Load documents
+    const docsPath = path.join(this.kbPath, 'documents');
+    if (fs.existsSync(docsPath)) {
+      const files = fs.readdirSync(docsPath);
+      files.forEach(file => {
+        if (file.endsWith('.json')) {
+          const content = fs.readFileSync(path.join(docsPath, file), 'utf-8');
+          const doc = JSON.parse(content);
+          this.documents.set(doc.id, doc);
+        }
+      });
+    } else {
+      throw new Error(`Documents directory not found: ${docsPath}`);
+    }
+
+    // Load chunks
+    const chunksPath = path.join(this.kbPath, 'chunks');
+    if (fs.existsSync(chunksPath)) {
+      const files = fs.readdirSync(chunksPath);
+      files.forEach(file => {
+        if (file.endsWith('.json')) {
+          const content = fs.readFileSync(path.join(chunksPath, file), 'utf-8');
+          const chunks = JSON.parse(content);
+          const docId = file.replace('.json', '');
+          this.chunks.set(docId, chunks);
+        }
+      });
+    } else {
+      throw new Error(`Chunks directory not found: ${chunksPath}`);
+    }
+
+    // Load embeddings (optional)
+    const embeddingsPath = path.join(this.kbPath, 'embeddings');
+    if (fs.existsSync(embeddingsPath)) {
+      const files = fs.readdirSync(embeddingsPath);
+      files.forEach(file => {
+        if (file.endsWith('.json')) {
+          const content = fs.readFileSync(path.join(embeddingsPath, file), 'utf-8');
+          const embeddings = JSON.parse(content);
+          const docId = file.replace('.json', '');
+          this.embeddings.set(docId, embeddings);
+        }
+      });
+    }
+
+    console.log(`✅ Loaded ${this.documents.size} documents`);
+    console.log(`✅ Loaded chunks for ${this.chunks.size} documents`);
+    if (this.embeddings.size > 0) {
+      console.log(`✅ Loaded embeddings for ${this.embeddings.size} documents`);
+    }
+  }
+
+  async upload(sendEmbeddings = false, sendChunks = false) {
+    // Validate server before uploading
+    await this.validateExternalServer();
+
+    if (this.documents.size === 0) {
+      throw new Error('No documents found in knowledge base');
+    }
+
+    if (sendEmbeddings && this.embeddings.size === 0) {
+      throw new Error('No embeddings found. Use --with-embeddings only if embeddings exist in the KB.');
+    }
+
+    if (sendChunks && this.chunks.size === 0) {
+      throw new Error('No chunks found. Use --chunks-only only if chunks exist in the KB.');
+    }
+
+    let mode = 'Raw content';
+    if (sendEmbeddings) {
+      mode = 'Chunks with embeddings';
+    } else if (sendChunks) {
+      mode = 'Chunks only';
+    }
+
+    console.log(`\n📤 Starting upload to external server...`);
+    console.log(`   Mode: ${mode}\n`);
+
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const [docId, doc] of this.documents) {
+      try {
+        console.log(`\n📄 Processing: ${doc.relativePath || doc.title || docId}`);
+
+        // Get chunks for this document
+        const chunks = this.chunks.get(docId) || [];
+        doc.chunks = chunks;
+
+        if (sendEmbeddings) {
+          // Send chunks with embeddings
+          const embeddings = this.embeddings.get(docId);
+          if (!embeddings || embeddings.length === 0) {
+            console.warn(`   ⚠️  No embeddings found for this document, skipping...`);
+            failCount++;
+            continue;
+          }
+
+          // Merge embeddings into chunks
+          const embeddingMap = new Map(embeddings.map(e => [e.id, e.embedding]));
+          doc.chunks = chunks.map(chunk => ({
+            ...chunk,
+            embedding: embeddingMap.get(chunk.id)
+          }));
+
+          // Verify all chunks have embeddings
+          const missingEmbeddings = doc.chunks.filter(chunk => !chunk.embedding);
+          if (missingEmbeddings.length > 0) {
+            console.warn(`   ⚠️  ${missingEmbeddings.length} chunks missing embeddings, skipping...`);
+            failCount++;
+            continue;
+          }
+
+          const options = {
+            chunkSize: 1000,
+            chunkOverlap: 200,
+            sendEmbeddings: true
+          };
+
+          await this.externalServer.sendEmbeddings(doc, options);
+          successCount++;
+        } else if (sendChunks) {
+          // Send chunks only (no embeddings)
+          if (chunks.length === 0) {
+            console.warn(`   ⚠️  No chunks found for this document, skipping...`);
+            failCount++;
+            continue;
+          }
+
+          // Chunks are already in doc.chunks, buildPayload will handle it
+          const options = {
+            chunkSize: 1000,
+            chunkOverlap: 200,
+            sendEmbeddings: false,
+            sendChunks: true // Indicate we're sending chunks (not raw content)
+          };
+
+          await this.externalServer.sendDocument(doc, options);
+          successCount++;
+        } else {
+          // Send raw content (reconstruct from chunks if available)
+          if (chunks.length > 0) {
+            doc.content = chunks.map(chunk => chunk.content).join('\n\n');
+          }
+
+          const options = {
+            chunkSize: 1000,
+            chunkOverlap: 200,
+            sendEmbeddings: false
+          };
+
+          await this.externalServer.sendDocument(doc, options);
+          successCount++;
+        }
+      } catch (error) {
+        console.error(`   ❌ Failed: ${error.message}`);
+        failCount++;
+      }
+    }
+
+    console.log(`\n✨ Upload complete!`);
+    console.log(`   ✅ Successful: ${successCount}`);
+    console.log(`   ❌ Failed: ${failCount}`);
+    console.log(`   📊 Total: ${this.documents.size}`);
+  }
+}
+
+// CLI handling
+if (require.main === module) {
+  const args = process.argv.slice(2);
+
+  // Parse arguments
+  let kbPath = './knowledge-base';
+  let sendEmbeddings = false;
+  let sendChunks = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    
+    if (arg === '--kb' || arg === '--kb-path') {
+      kbPath = args[++i];
+    } else if (arg === '--with-embeddings') {
+      sendEmbeddings = true;
+    } else if (arg === '--chunks-only') {
+      sendChunks = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`
+Usage: src-to-kb-upload [options]
+
+Upload existing local knowledge base to external server.
+
+Options:
+  --kb, --kb-path      Knowledge base directory path (default: ./knowledge-base)
+  --chunks-only        Upload chunks only (requires chunks in KB)
+  --with-embeddings    Upload chunks with embeddings (requires embeddings in KB)
+  --help, -h            Show this help message
+
+Examples:
+  src-to-kb-upload --kb ./knowledge-base
+  src-to-kb-upload --kb ./knowledge-base --chunks-only
+  src-to-kb-upload --kb ./knowledge-base --with-embeddings
+
+Note: Requires EXTERNAL_KB_URL environment variable to be set.
+      `);
+      process.exit(0);
+    }
+  }
+
+  // Run upload
+  (async () => {
+    try {
+      const uploader = new KnowledgeBaseUploader(kbPath);
+      uploader.loadKnowledgeBase();
+      await uploader.upload(sendEmbeddings, sendChunks);
+      process.exit(0);
+    } catch (error) {
+      // Error message already contains detailed guidance from validation
+      console.error(`\n❌ ${error.message}`);
+      process.exit(1);
+    }
+  })();
+}
+
+module.exports = { KnowledgeBaseUploader };
+

--- a/validation-utils.js
+++ b/validation-utils.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Validation Utilities
+ * Centralized validation functions for OpenAI API keys and external server connections
+ */
+
+/**
+ * Validate OpenAI API key by making a test API call
+ * @param {string} openaiApiKey - OpenAI API key to validate
+ * @throws {Error} If key is missing, invalid, or API call fails
+ */
+async function validateOpenAIKey(openaiApiKey) {
+  if (!openaiApiKey) {
+    throw new Error('❌ OpenAI API key is required. Please set OPENAI_API_KEY environment variable or provide it via --openai-key');
+  }
+
+  // Test API key with a minimal request (this will catch all issues: missing, invalid format, invalid key)
+  console.log('🔍 Validating OpenAI API key...');
+  try {
+    const response = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${openaiApiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'text-embedding-3-large',
+        input: ['test'] // Minimal test input
+      })
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('❌ Invalid OpenAI API key. Please check your OPENAI_API_KEY and ensure it is valid');
+      } else if (response.status === 429) {
+        throw new Error('❌ OpenAI API rate limit exceeded. Please try again later');
+      } else {
+        throw new Error(`❌ OpenAI API error (${response.status}): ${data.error?.message || 'Unknown error'}`);
+      }
+    }
+
+    console.log('✅ OpenAI API key validated successfully\n');
+  } catch (error) {
+    if (error.message.startsWith('❌')) {
+      throw error; // Re-throw our formatted errors
+    }
+    throw new Error(`❌ Failed to validate OpenAI API key: ${error.message}`);
+  }
+}
+
+/**
+ * Validate external server connection and authentication
+ * Wrapper around ExternalServerService.validateServer() with consistent error handling
+ * @param {ExternalServerService} externalServer - External server service instance
+ * @param {Object} options - Validation options
+ * @param {boolean} options.skipIfNotSet - Skip validation if external server is not configured (default: true)
+ * @param {boolean} options.cacheResult - Cache validation result to avoid re-validation (default: false)
+ * @returns {Promise<void>}
+ * @throws {Error} If server is unavailable or authentication fails
+ */
+async function validateExternalServer(externalServer, options = {}) {
+  const { skipIfNotSet = true, cacheResult = false } = options;
+
+  if (!externalServer) {
+    if (skipIfNotSet) {
+      return; // No external server, skip validation
+    }
+    throw new Error('External server is not configured');
+  }
+
+  // Cache validation result if requested (for commands that might validate multiple times)
+  if (cacheResult && externalServer._serverValidated) {
+    return;
+  }
+
+  try {
+    await externalServer.validateServer();
+    if (cacheResult) {
+      externalServer._serverValidated = true;
+    }
+  } catch (error) {
+    // All validation errors should stop processing
+    // Error message already contains detailed guidance, just re-throw
+    throw error;
+  }
+}
+
+module.exports = {
+  validateOpenAIKey,
+  validateExternalServer
+};
+


### PR DESCRIPTION
- Renamed --embeddings to --with-embeddings and added --chunks-only flag
- Upgraded embedding model from text-embedding-ada-002 to text-embedding-3-large
- EXTERNAL_KB_SEARCH_URL is now required for external server search (no auto-generation)
- Centralized validation functions in validation-utils.js to eliminate code duplication
- Early validation for OpenAI API key and external server with health check before processing
- Added upload command to upload chunks + embeddings to external server from local kb and
- Added --chunks-only and --with-embeddings flags to upload command
- Improved error handling with fail-fast behavior and clearer error messages