### PR TITLE
feat: add pluggable AST analyzer system with tree-sitter

### DIFF
--- a/analyzers/__tests__/integration.test.js
+++ b/analyzers/__tests__/integration.test.js
@@ -1,0 +1,293 @@
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { getAnalyzer, getAnalyzerStats, resetRegistry } = require('../index');
+const { validateChunk } = require('../shared/metadata-schema');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+// Create a mixed-language fixture directory for integration testing
+function createFixtureProject() {
+  const projectDir = path.join(FIXTURES_DIR, 'mixed-project');
+
+  // Ruby file
+  const rubyDir = path.join(projectDir, 'app', 'models');
+  fs.mkdirSync(rubyDir, { recursive: true });
+  fs.writeFileSync(path.join(rubyDir, 'user.rb'), `
+class User < ApplicationRecord
+  has_many :orders
+  validates :email, presence: true
+
+  def full_name
+    "\#{first_name} \#{last_name}"
+  end
+end
+`);
+
+  // TypeScript file
+  const tsDir = path.join(projectDir, 'src', 'services');
+  fs.mkdirSync(tsDir, { recursive: true });
+  fs.writeFileSync(path.join(tsDir, 'user.service.ts'), `
+import { Injectable } from '@nestjs/common';
+
+export class UserService {
+  async findById(id: string): Promise<User | null> {
+    return null;
+  }
+}
+`);
+
+  // Dart file
+  const dartDir = path.join(projectDir, 'lib', 'models');
+  fs.mkdirSync(dartDir, { recursive: true });
+  fs.writeFileSync(path.join(dartDir, 'user.dart'), `
+class User {
+  final String id;
+  final String name;
+
+  User({required this.id, required this.name});
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(id: json['id'], name: json['name']);
+  }
+}
+`);
+
+  // Python file (no analyzer available — should fall back)
+  const pyDir = path.join(projectDir, 'scripts');
+  fs.mkdirSync(pyDir, { recursive: true });
+  fs.writeFileSync(path.join(pyDir, 'migrate.py'), `
+def run_migration():
+    print("Running migration...")
+
+if __name__ == "__main__":
+    run_migration()
+`);
+
+  // Go file (no analyzer available — should fall back)
+  fs.writeFileSync(path.join(pyDir, 'server.go'), `
+package main
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+`);
+
+  // Rails indicator for enrichment
+  const configDir = path.join(projectDir, 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'routes.rb'), `
+Rails.application.routes.draw do
+  resources :users
+end
+`);
+
+  return projectDir;
+}
+
+function cleanupFixtureProject() {
+  const projectDir = path.join(FIXTURES_DIR, 'mixed-project');
+  try {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  } catch (err) {
+    // Ignore cleanup errors
+  }
+}
+
+describe('Analyzer Integration', () => {
+  let projectDir;
+
+  before(() => {
+    resetRegistry();
+    projectDir = createFixtureProject();
+  });
+
+  after(() => {
+    cleanupFixtureProject();
+    resetRegistry();
+  });
+
+  describe('getAnalyzer()', () => {
+    it('returns an analyzer for .rb files', () => {
+      const analyzer = getAnalyzer('.rb', projectDir);
+      // May return null if tree-sitter-ruby is not installed, that's ok
+      if (analyzer) {
+        assert.ok(typeof analyzer.parse === 'function');
+        assert.ok(typeof analyzer.extractMetadata === 'function');
+        assert.ok(typeof analyzer.chunk === 'function');
+        assert.ok(typeof analyzer.enrich === 'function');
+      }
+    });
+
+    it('returns an analyzer for .ts files', () => {
+      const analyzer = getAnalyzer('.ts', projectDir);
+      if (analyzer) {
+        assert.ok(typeof analyzer.parse === 'function');
+        assert.ok(typeof analyzer.extractMetadata === 'function');
+      }
+    });
+
+    it('returns an analyzer for .tsx files', () => {
+      const analyzer = getAnalyzer('.tsx', projectDir);
+      if (analyzer) {
+        assert.ok(typeof analyzer.parse === 'function');
+      }
+    });
+
+    it('returns an analyzer for .dart files', () => {
+      const analyzer = getAnalyzer('.dart', projectDir);
+      if (analyzer) {
+        assert.ok(typeof analyzer.parse === 'function');
+        assert.ok(typeof analyzer.extractMetadata === 'function');
+      }
+    });
+
+    it('returns null for unsupported extensions', () => {
+      assert.equal(getAnalyzer('.py', projectDir), null);
+      assert.equal(getAnalyzer('.go', projectDir), null);
+      assert.equal(getAnalyzer('.java', projectDir), null);
+      assert.equal(getAnalyzer('.js', projectDir), null);
+      assert.equal(getAnalyzer('.css', projectDir), null);
+    });
+  });
+
+  describe('end-to-end processing', () => {
+    it('produces enriched chunks for Ruby files when analyzer is available', () => {
+      const analyzer = getAnalyzer('.rb', projectDir);
+      if (!analyzer) {
+        console.log('   ⏭️  Skipping: tree-sitter-ruby not installed');
+        return;
+      }
+
+      const content = fs.readFileSync(path.join(projectDir, 'app', 'models', 'user.rb'), 'utf8');
+      const tree = analyzer.parse(path.join(projectDir, 'app', 'models', 'user.rb'), content);
+      assert.ok(tree, 'Should parse Ruby file');
+
+      const metadata = analyzer.extractMetadata(tree, 'app/models/user.rb', content);
+      assert.ok(metadata, 'Should extract metadata');
+      assert.equal(metadata.name, 'User');
+
+      const enrichedMetadata = analyzer.enrich(metadata, tree, content, 'app/models/user.rb');
+      assert.ok(enrichedMetadata, 'Should enrich metadata');
+
+      const chunks = analyzer.chunk(tree, content, { maxSize: 1000 }, 'app/models/user.rb');
+      assert.ok(chunks.length > 0, 'Should produce chunks');
+
+      // Verify chunk format
+      for (const chunk of chunks) {
+        const enrichedChunk = { ...chunk, ast: enrichedMetadata };
+        const result = validateChunk(enrichedChunk);
+        assert.ok(result.valid, `Chunk validation failed: ${result.errors.join(', ')}`);
+      }
+    });
+
+    it('produces enriched chunks for TypeScript files when analyzer is available', () => {
+      const analyzer = getAnalyzer('.ts', projectDir);
+      if (!analyzer) {
+        console.log('   ⏭️  Skipping: tree-sitter-typescript not installed');
+        return;
+      }
+
+      const content = fs.readFileSync(path.join(projectDir, 'src', 'services', 'user.service.ts'), 'utf8');
+      const tree = analyzer.parse(path.join(projectDir, 'src', 'services', 'user.service.ts'), content);
+      assert.ok(tree, 'Should parse TypeScript file');
+
+      const metadata = analyzer.extractMetadata(tree, 'src/services/user.service.ts', content);
+      assert.ok(metadata, 'Should extract metadata');
+
+      const chunks = analyzer.chunk(tree, content, { maxSize: 1000 }, 'src/services/user.service.ts');
+      assert.ok(chunks.length > 0, 'Should produce chunks');
+    });
+
+    it('produces enriched chunks for Dart files when analyzer is available', () => {
+      const analyzer = getAnalyzer('.dart', projectDir);
+      if (!analyzer) {
+        console.log('   ⏭️  Skipping: tree-sitter-dart not installed');
+        return;
+      }
+
+      const content = fs.readFileSync(path.join(projectDir, 'lib', 'models', 'user.dart'), 'utf8');
+      const tree = analyzer.parse(path.join(projectDir, 'lib', 'models', 'user.dart'), content);
+      if (!tree) {
+        // tree-sitter-dart grammar failed to load — graceful fallback
+        console.log('   ⏭️  Skipping: tree-sitter-dart grammar unavailable');
+        return;
+      }
+
+      const metadata = analyzer.extractMetadata(tree, 'lib/models/user.dart', content);
+      assert.ok(metadata, 'Should extract metadata');
+    });
+
+    it('returns null analyzer for Python files (text fallback expected)', () => {
+      const analyzer = getAnalyzer('.py', projectDir);
+      assert.equal(analyzer, null, 'Should return null for .py files');
+    });
+
+    it('returns null analyzer for Go files (text fallback expected)', () => {
+      const analyzer = getAnalyzer('.go', projectDir);
+      assert.equal(analyzer, null, 'Should return null for .go files');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('chunks without ast field pass validation', () => {
+      // Simulate a text-based chunk (no ast field)
+      const textChunk = {
+        id: 'doc_test_chunk_0',
+        index: 0,
+        content: 'def run_migration():\n    print("Running migration...")',
+        startLine: 1,
+        endLine: 2,
+        size: 52,
+      };
+      const result = validateChunk(textChunk);
+      assert.ok(result.valid, `Text chunk should be valid: ${result.errors.join(', ')}`);
+    });
+
+    it('enriched chunks with ast field pass validation', () => {
+      const enrichedChunk = {
+        id: 'doc_test_chunk_0',
+        index: 0,
+        content: 'class User < ApplicationRecord\nend',
+        startLine: 1,
+        endLine: 2,
+        size: 34,
+        ast: {
+          type: 'class',
+          name: 'User',
+          inherits: 'ApplicationRecord',
+          scope: ['app', 'models'],
+          defines: [{ name: 'User', type: 'class' }],
+          references: ['ApplicationRecord'],
+        },
+      };
+      const result = validateChunk(enrichedChunk);
+      assert.ok(result.valid, `Enriched chunk should be valid: ${result.errors.join(', ')}`);
+    });
+  });
+
+  describe('framework detection', () => {
+    it('detects Rails project when config/routes.rb exists', () => {
+      const { detectRails } = require('../index');
+      assert.ok(detectRails(projectDir), 'Should detect Rails project');
+    });
+
+    it('does not detect Flutter for non-Flutter project', () => {
+      const { detectFlutter } = require('../index');
+      assert.equal(detectFlutter(projectDir), false, 'Should not detect Flutter');
+    });
+  });
+
+  describe('analyzer stats', () => {
+    it('returns stats object', () => {
+      const stats = getAnalyzerStats();
+      assert.ok(stats, 'Should return stats');
+      assert.ok(Array.isArray(stats.analyzersUsed), 'analyzersUsed should be an array');
+      assert.ok(Array.isArray(stats.enrichmentsApplied), 'enrichmentsApplied should be an array');
+    });
+  });
+});

--- a/analyzers/base-analyzer.js
+++ b/analyzers/base-analyzer.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { splitAST } = require('./shared/chunk-splitter');
+
+/**
+ * @abstract
+ * Base class for all language analyzers.
+ * Subclasses must implement parse() and extractMetadata().
+ * chunk() has a default implementation using shared/chunk-splitter.js.
+ */
+class BaseAnalyzer {
+  /**
+   * Parse source code into a tree-sitter AST.
+   * @param {string} filePath - Path to the file
+   * @param {string} content - Raw file content
+   * @returns {object|null} Parsed tree-sitter tree, or null if parsing fails
+   */
+  parse(filePath, content) {
+    throw new Error('Not implemented: parse() must be overridden by subclass');
+  }
+
+  /**
+   * Extract semantic metadata from parsed AST.
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} filePath - Path for context (e.g., detecting Rails conventions from path)
+   * @param {string} content - Raw content (for extracting text from AST nodes)
+   * @returns {object} Metadata object (structure varies by analyzer)
+   */
+  extractMetadata(tree, filePath, content) {
+    throw new Error('Not implemented: extractMetadata() must be overridden by subclass');
+  }
+
+  /**
+   * Split AST into structurally-aware chunks.
+   * Default implementation uses shared/chunk-splitter.js.
+   * Subclasses can override for language-specific chunking logic.
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} content - Raw content
+   * @param {object} options - { maxSize, overlap }
+   * @param {string} [filePath] - File path for context
+   * @returns {Array<object>} Array of chunk objects
+   */
+  chunk(tree, content, options, filePath) {
+    return splitAST(tree, content, options, filePath);
+  }
+
+  /**
+   * Optional framework-specific enrichment.
+   * Called after base metadata extraction if an enrichment layer is registered.
+   * @param {object} metadata - Base metadata from extractMetadata()
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} content - Raw content
+   * @param {string} filePath - File path
+   * @returns {object} Enriched metadata
+   */
+  enrich(metadata, tree, content, filePath) {
+    return metadata;
+  }
+}
+
+module.exports = { BaseAnalyzer };

--- a/analyzers/dart/__tests__/dart-analyzer.test.js
+++ b/analyzers/dart/__tests__/dart-analyzer.test.js
@@ -1,0 +1,645 @@
+'use strict';
+
+const { describe, it, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { DartAnalyzer } = require('../index');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+/**
+ * Helper: read a fixture file.
+ * @param {string} filename
+ * @returns {string}
+ */
+function readFixture(filename) {
+  return fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf-8');
+}
+
+/**
+ * Helper: check if tree-sitter-dart is available.
+ * @returns {boolean}
+ */
+function isTreeSitterDartAvailable() {
+  try {
+    require('tree-sitter');
+    require('tree-sitter-dart');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const treeSitterAvailable = isTreeSitterDartAvailable();
+
+// ---------------------------------------------------------------------------
+// Tests that do NOT require tree-sitter-dart
+// ---------------------------------------------------------------------------
+
+describe('DartAnalyzer (no tree-sitter required)', () => {
+  let analyzer;
+
+  beforeEach(() => {
+    analyzer = new DartAnalyzer();
+  });
+
+  it('returns null from parse() when tree-sitter-dart is unavailable', (t) => {
+    if (treeSitterAvailable) {
+      t.skip('tree-sitter-dart IS available; cannot test unavailable path');
+      return;
+    }
+    const result = analyzer.parse('test.dart', 'class Foo {}');
+    assert.equal(result, null);
+  });
+
+  it('is an instance of BaseAnalyzer', () => {
+    const { BaseAnalyzer } = require('../../base-analyzer');
+    assert.ok(analyzer instanceof BaseAnalyzer);
+  });
+
+  it('has parse, extractMetadata, chunk, and enrich methods', () => {
+    assert.equal(typeof analyzer.parse, 'function');
+    assert.equal(typeof analyzer.extractMetadata, 'function');
+    assert.equal(typeof analyzer.chunk, 'function');
+    assert.equal(typeof analyzer.enrich, 'function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests that REQUIRE tree-sitter-dart
+// ---------------------------------------------------------------------------
+
+describe('DartAnalyzer (tree-sitter required)', { skip: !treeSitterAvailable && 'tree-sitter-dart not installed' }, () => {
+  let analyzer;
+
+  beforeEach(() => {
+    analyzer = new DartAnalyzer();
+  });
+
+  // -----------------------------------------------------------------------
+  // Parsing
+  // -----------------------------------------------------------------------
+
+  describe('parse()', () => {
+    it('parses valid Dart source and returns a tree', () => {
+      const content = 'class Foo {}';
+      const tree = analyzer.parse('test.dart', content);
+      assert.ok(tree, 'Expected a non-null tree');
+      assert.ok(tree.rootNode, 'Expected tree to have a rootNode');
+    });
+
+    it('returns a tree even for empty content', () => {
+      const tree = analyzer.parse('empty.dart', '');
+      assert.ok(tree, 'Expected a non-null tree even for empty content');
+    });
+
+    it('parses the sample_repository.dart fixture', () => {
+      const content = readFixture('sample_repository.dart');
+      const tree = analyzer.parse('sample_repository.dart', content);
+      assert.ok(tree, 'Expected tree for repository fixture');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Class extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - classes', () => {
+    it('extracts a simple class with name', () => {
+      const content = 'class MyWidget {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      assert.ok(Array.isArray(results));
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.equal(cls.name, 'MyWidget');
+      assert.equal(cls.exported, true);
+      assert.equal(cls.abstract, false);
+    });
+
+    it('extracts abstract classes', () => {
+      const content = 'abstract class BaseRepository {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.equal(cls.name, 'BaseRepository');
+      assert.equal(cls.abstract, true);
+    });
+
+    it('detects private classes (underscore prefix)', () => {
+      const content = 'class _InternalHelper {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.equal(cls.name, '_InternalHelper');
+      assert.equal(cls.exported, false);
+    });
+
+    it('extracts class inheritance (extends)', () => {
+      const content = 'class OrderBloc extends Bloc<OrderEvent, OrderState> {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.ok(cls.inherits, 'Expected inherits to be set');
+      assert.ok(cls.inherits.includes('Bloc'), `Expected inherits to include "Bloc", got: ${cls.inherits}`);
+    });
+
+    it('extracts implements clause', () => {
+      const content = 'class OrderRepositoryImpl implements OrderRepository {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.ok(Array.isArray(cls.implements));
+      assert.ok(cls.implements.length > 0, 'Expected at least one implement');
+      assert.ok(cls.implements.some(i => i.includes('OrderRepository')),
+        `Expected implements to include OrderRepository, got: ${JSON.stringify(cls.implements)}`);
+    });
+
+    it('extracts with clause (mixins)', () => {
+      const content = 'class MyWidget extends StatelessWidget with LoggingMixin {}';
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected to find a class');
+      assert.ok(Array.isArray(cls.mixins));
+      assert.ok(cls.mixins.length > 0, 'Expected at least one mixin');
+      assert.ok(cls.mixins.some(m => m.includes('LoggingMixin')),
+        `Expected mixins to include LoggingMixin, got: ${JSON.stringify(cls.mixins)}`);
+    });
+
+    it('extracts from the sample_repository fixture', () => {
+      const content = readFixture('sample_repository.dart');
+      const tree = analyzer.parse('lib/repositories/sample_repository.dart', content);
+      const results = analyzer.extractMetadata(tree, 'lib/repositories/sample_repository.dart', content);
+      assert.ok(results.length > 0, 'Expected at least one definition');
+
+      // Should find the abstract class
+      const abstractRepo = results.find(r => r.type === 'class' && r.name === 'OrderRepository');
+      assert.ok(abstractRepo, 'Expected to find OrderRepository class');
+      assert.equal(abstractRepo.abstract, true);
+
+      // Should find the implementation class
+      const implRepo = results.find(r => r.type === 'class' && r.name === 'OrderRepositoryImpl');
+      assert.ok(implRepo, 'Expected to find OrderRepositoryImpl class');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Method extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - methods', () => {
+    it('extracts methods with visibility detection', () => {
+      const content = `
+class MyService {
+  void doPublicThing() {}
+  void _doPrivateThing() {}
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const publicMethod = cls.defines.find(d => d.name === 'doPublicThing');
+      const privateMethod = cls.defines.find(d => d.name === '_doPrivateThing');
+
+      if (publicMethod) {
+        assert.equal(publicMethod.visibility, 'public');
+      }
+      if (privateMethod) {
+        assert.equal(privateMethod.visibility, 'private');
+      }
+
+      // At least one should be found (AST or text fallback)
+      assert.ok(publicMethod || privateMethod,
+        'Expected to find at least one method from the class body');
+    });
+
+    it('detects async methods', () => {
+      const content = `
+class ApiService {
+  Future<List<String>> fetchData() async {
+    return [];
+  }
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const method = cls.defines.find(d => d.name === 'fetchData');
+      if (method) {
+        assert.equal(method.async, true);
+      }
+    });
+
+    it('extracts method return types', () => {
+      const content = `
+class Calculator {
+  int add(int a, int b) {
+    return a + b;
+  }
+  Future<String> greet() async {
+    return 'hello';
+  }
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      // Check that return types are captured (either via AST or text fallback)
+      const addMethod = cls.defines.find(d => d.name === 'add');
+      if (addMethod && addMethod.returnType) {
+        assert.ok(addMethod.returnType.includes('int'),
+          `Expected return type to include 'int', got: ${addMethod.returnType}`);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Constructor extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - constructors', () => {
+    it('extracts default constructor', () => {
+      const content = `
+class User {
+  User(this.name);
+  final String name;
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const ctor = cls.defines.find(d => d.type === 'constructor' && d.name === 'User');
+      if (ctor) {
+        assert.equal(ctor.named, false);
+        assert.equal(ctor.factory, false);
+      }
+    });
+
+    it('extracts named constructors', () => {
+      const content = `
+class User {
+  User(this.name);
+  User.fromJson(Map<String, dynamic> json) : name = json['name'] as String;
+  final String name;
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const namedCtor = cls.defines.find(d =>
+        d.type === 'constructor' && d.name === 'User.fromJson'
+      );
+      if (namedCtor) {
+        assert.equal(namedCtor.named, true);
+      }
+    });
+
+    it('extracts factory constructors', () => {
+      const content = `
+class Singleton {
+  factory Singleton() => _instance;
+  Singleton._internal();
+  static final Singleton _instance = Singleton._internal();
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const factoryCtor = cls.defines.find(d =>
+        d.type === 'constructor' && d.factory === true
+      );
+      // Factory constructors may be detected via AST or text fallback
+      if (factoryCtor) {
+        assert.equal(factoryCtor.factory, true);
+      }
+    });
+
+    it('extracts const constructors', () => {
+      const content = `
+class Point {
+  const Point(this.x, this.y);
+  final double x;
+  final double y;
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const constCtor = cls.defines.find(d =>
+        d.type === 'constructor' && d.const === true
+      );
+      if (constCtor) {
+        assert.equal(constCtor.const, true);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Field extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - fields', () => {
+    it('extracts final fields with types', () => {
+      const content = `
+class Config {
+  final String name;
+  final int count;
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const nameField = cls.defines.find(d => d.type === 'field' && d.name === 'name');
+      if (nameField) {
+        assert.equal(nameField.final, true);
+        assert.ok(nameField.fieldType && nameField.fieldType.includes('String'),
+          `Expected field type to include String, got: ${nameField.fieldType}`);
+      }
+    });
+
+    it('extracts late fields', () => {
+      const content = `
+class Service {
+  late final String url;
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const field = cls.defines.find(d => d.type === 'field' && d.name === 'url');
+      if (field) {
+        assert.equal(field.late, true);
+        assert.equal(field.final, true);
+      }
+    });
+
+    it('detects private fields', () => {
+      const content = `
+class Cache {
+  final List<String> _items = [];
+}`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+
+      const field = cls.defines.find(d => d.type === 'field' && d.name === '_items');
+      if (field) {
+        assert.equal(field.visibility, 'private');
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Import extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - imports', () => {
+    it('extracts import statements', () => {
+      const content = `
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../models/order_model.dart';
+
+class MyWidget {}
+`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      assert.ok(results.length > 0);
+
+      const primary = results[0];
+      assert.ok(primary.imports, 'Expected imports array');
+      assert.ok(primary.imports.length >= 2, `Expected at least 2 imports, got ${primary.imports.length}`);
+
+      const flutterImport = primary.imports.find(i => i.from && i.from.includes('flutter/material.dart'));
+      if (flutterImport) {
+        assert.ok(flutterImport.name.includes('material.dart'));
+      }
+    });
+
+    it('extracts show/hide clauses', () => {
+      const content = `
+import 'package:flutter/material.dart' show Container, Text;
+import 'dart:math' hide Random;
+
+class MyWidget {}
+`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const primary = results[0];
+      assert.ok(primary.imports, 'Expected imports array');
+
+      const showImport = primary.imports.find(i =>
+        i.from && i.from.includes('material.dart') && i.show && i.show.length > 0
+      );
+      if (showImport) {
+        assert.ok(showImport.show.includes('Container') || showImport.show.includes('Text'),
+          `Expected show clause to include Container or Text, got: ${JSON.stringify(showImport.show)}`);
+      }
+
+      const hideImport = primary.imports.find(i =>
+        i.from && i.from.includes('dart:math') && i.hide && i.hide.length > 0
+      );
+      if (hideImport) {
+        assert.ok(hideImport.hide.includes('Random'),
+          `Expected hide clause to include Random, got: ${JSON.stringify(hideImport.hide)}`);
+      }
+    });
+
+    it('extracts as clause (prefix)', () => {
+      const content = `
+import 'dart:math' as math;
+
+class Foo {}
+`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const primary = results[0];
+      assert.ok(primary.imports, 'Expected imports array');
+
+      const asImport = primary.imports.find(i => i.as === 'math');
+      if (asImport) {
+        assert.equal(asImport.as, 'math');
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Enum extraction
+  // -----------------------------------------------------------------------
+
+  describe('extractMetadata() - enums', () => {
+    it('extracts simple enums with members', () => {
+      const content = `enum OrderStatus { pending, confirmed, shipped, cancelled }`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+      const enumDef = results.find(r => r.type === 'enum');
+      assert.ok(enumDef, 'Expected to find an enum');
+      assert.equal(enumDef.name, 'OrderStatus');
+      assert.ok(Array.isArray(enumDef.members), 'Expected members array');
+      assert.ok(enumDef.members.length > 0, 'Expected at least one member');
+
+      const memberNames = enumDef.members.map(m => m.name);
+      assert.ok(memberNames.includes('pending'), `Expected "pending" member, got: ${JSON.stringify(memberNames)}`);
+    });
+
+    it('extracts enums from the model fixture', () => {
+      const content = readFixture('sample_model.dart');
+      const tree = analyzer.parse('lib/models/sample_model.dart', content);
+      const results = analyzer.extractMetadata(tree, 'lib/models/sample_model.dart', content);
+
+      const orderStatus = results.find(r => r.type === 'enum' && r.name === 'OrderStatus');
+      assert.ok(orderStatus, 'Expected to find OrderStatus enum');
+      assert.ok(orderStatus.members.length >= 2, 'Expected multiple enum members');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scope derivation
+  // -----------------------------------------------------------------------
+
+  describe('scope derivation', () => {
+    it('derives scope from lib/ path', () => {
+      const content = 'class Foo {}';
+      const tree = analyzer.parse('lib/src/models/foo.dart', content);
+      const results = analyzer.extractMetadata(tree, 'lib/src/models/foo.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+      assert.ok(Array.isArray(cls.scope));
+      assert.ok(cls.scope.includes('lib'), `Expected scope to include "lib", got: ${JSON.stringify(cls.scope)}`);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Full fixture tests
+  // -----------------------------------------------------------------------
+
+  describe('full fixture: sample_bloc.dart', () => {
+    it('extracts multiple classes from the bloc file', () => {
+      const content = readFixture('sample_bloc.dart');
+      const tree = analyzer.parse('lib/blocs/sample_bloc.dart', content);
+      const results = analyzer.extractMetadata(tree, 'lib/blocs/sample_bloc.dart', content);
+
+      assert.ok(results.length >= 2, `Expected at least 2 definitions, got ${results.length}`);
+
+      // Should find OrderBloc
+      const bloc = results.find(r => r.type === 'class' && r.name === 'OrderBloc');
+      assert.ok(bloc, 'Expected to find OrderBloc class');
+
+      // Should find some event/state classes
+      const classNames = results.filter(r => r.type === 'class').map(r => r.name);
+      assert.ok(classNames.length >= 2, `Expected multiple classes, got: ${JSON.stringify(classNames)}`);
+    });
+  });
+
+  describe('full fixture: sample_widget.dart', () => {
+    it('extracts widget classes', () => {
+      const content = readFixture('sample_widget.dart');
+      const tree = analyzer.parse('lib/screens/sample_widget.dart', content);
+      const results = analyzer.extractMetadata(tree, 'lib/screens/sample_widget.dart', content);
+
+      assert.ok(results.length >= 1, 'Expected at least one definition');
+
+      const widget = results.find(r =>
+        r.type === 'class' && r.name === 'OrderListScreen'
+      );
+      assert.ok(widget, 'Expected to find OrderListScreen class');
+      assert.ok(widget.inherits && widget.inherits.includes('StatelessWidget'),
+        `Expected inherits to include StatelessWidget, got: ${widget.inherits}`);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Chunking
+  // -----------------------------------------------------------------------
+
+  describe('chunk()', () => {
+    it('produces chunks that respect class boundaries', () => {
+      const content = readFixture('sample_repository.dart');
+      const tree = analyzer.parse('sample_repository.dart', content);
+      const chunks = analyzer.chunk(tree, content, { maxSize: 300 }, 'sample_repository.dart');
+
+      assert.ok(Array.isArray(chunks), 'Expected chunks to be an array');
+      assert.ok(chunks.length >= 1, 'Expected at least one chunk');
+
+      for (const chunk of chunks) {
+        assert.ok(chunk.content, 'Each chunk should have content');
+        assert.ok(typeof chunk.startLine === 'number', 'Each chunk should have startLine');
+        assert.ok(typeof chunk.endLine === 'number', 'Each chunk should have endLine');
+        assert.ok(typeof chunk.size === 'number', 'Each chunk should have size');
+      }
+    });
+
+    it('keeps small files in a single chunk', () => {
+      const content = 'class Foo {\n  void bar() {}\n}';
+      const tree = analyzer.parse('foo.dart', content);
+      const chunks = analyzer.chunk(tree, content, { maxSize: 5000 }, 'foo.dart');
+
+      assert.ok(chunks.length >= 1, 'Expected at least one chunk');
+      // A small file should fit in one chunk
+      if (content.length < 5000) {
+        assert.equal(chunks.length, 1, 'Small file should produce exactly one chunk');
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+
+  describe('edge cases', () => {
+    it('handles files with only imports', () => {
+      const content = `
+import 'dart:async';
+import 'package:flutter/material.dart';
+`;
+      const tree = analyzer.parse('test.dart', content);
+      const results = analyzer.extractMetadata(tree, 'test.dart', content);
+
+      assert.ok(Array.isArray(results));
+      // Should produce file-level metadata
+      assert.ok(results.length >= 1);
+    });
+
+    it('handles files with syntax errors gracefully', () => {
+      const content = `
+class Broken {
+  void foo( {
+    // missing closing paren and brace
+`;
+      const tree = analyzer.parse('broken.dart', content);
+      // tree-sitter should still return a tree (with ERROR nodes)
+      if (tree) {
+        const results = analyzer.extractMetadata(tree, 'broken.dart', content);
+        // Should not throw; may return partial results or empty
+        assert.ok(Array.isArray(results));
+      }
+    });
+
+    it('handles empty class body', () => {
+      const content = 'class Empty {}';
+      const tree = analyzer.parse('empty.dart', content);
+      const results = analyzer.extractMetadata(tree, 'empty.dart', content);
+      const cls = results.find(r => r.type === 'class');
+      assert.ok(cls, 'Expected a class');
+      assert.equal(cls.name, 'Empty');
+      assert.ok(Array.isArray(cls.defines));
+    });
+  });
+});

--- a/analyzers/dart/__tests__/fixtures/sample_bloc.dart
+++ b/analyzers/dart/__tests__/fixtures/sample_bloc.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../models/order_model.dart';
+import '../repositories/order_repository.dart';
+
+// Events
+sealed class OrderEvent extends Equatable {
+  const OrderEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadOrders extends OrderEvent {
+  const LoadOrders();
+}
+
+class CreateOrder extends OrderEvent {
+  const CreateOrder({required this.title, required this.items});
+  final String title;
+  final List<String> items;
+
+  @override
+  List<Object?> get props => [title, items];
+}
+
+// States
+sealed class OrderState extends Equatable {
+  const OrderState();
+  @override
+  List<Object?> get props => [];
+}
+
+class OrderInitial extends OrderState {}
+class OrderLoading extends OrderState {}
+
+class OrderLoaded extends OrderState {
+  const OrderLoaded(this.orders);
+  final List<OrderModel> orders;
+
+  @override
+  List<Object?> get props => [orders];
+}
+
+class OrderError extends OrderState {
+  const OrderError(this.message);
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}
+
+// Bloc
+class OrderBloc extends Bloc<OrderEvent, OrderState> {
+  OrderBloc({required this.repository}) : super(OrderInitial()) {
+    on<LoadOrders>(_onLoadOrders);
+    on<CreateOrder>(_onCreateOrder);
+  }
+
+  final OrderRepository repository;
+
+  Future<void> _onLoadOrders(LoadOrders event, Emitter<OrderState> emit) async {
+    emit(OrderLoading());
+    try {
+      final orders = await repository.findAll();
+      emit(OrderLoaded(orders));
+    } catch (e) {
+      emit(OrderError(e.toString()));
+    }
+  }
+
+  Future<void> _onCreateOrder(CreateOrder event, Emitter<OrderState> emit) async {
+    emit(OrderLoading());
+    try {
+      await repository.create(title: event.title, items: event.items);
+      final orders = await repository.findAll();
+      emit(OrderLoaded(orders));
+    } catch (e) {
+      emit(OrderError(e.toString()));
+    }
+  }
+}

--- a/analyzers/dart/__tests__/fixtures/sample_model.dart
+++ b/analyzers/dart/__tests__/fixtures/sample_model.dart
@@ -1,0 +1,66 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'order_model.g.dart';
+
+enum OrderStatus { pending, confirmed, shipped, cancelled }
+
+@JsonSerializable()
+class OrderModel extends Equatable {
+  const OrderModel({
+    required this.id,
+    required this.title,
+    required this.status,
+    required this.items,
+    this.createdAt,
+  });
+
+  factory OrderModel.fromJson(Map<String, dynamic> json) =>
+      _$OrderModelFromJson(json);
+
+  final String id;
+  final String title;
+  final OrderStatus status;
+  final List<OrderItem> items;
+  final DateTime? createdAt;
+
+  Map<String, dynamic> toJson() => _$OrderModelToJson(this);
+
+  OrderModel copyWith({
+    String? id,
+    String? title,
+    OrderStatus? status,
+    List<OrderItem>? items,
+    DateTime? createdAt,
+  }) {
+    return OrderModel(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      status: status ?? this.status,
+      items: items ?? this.items,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, title, status, items, createdAt];
+}
+
+@JsonSerializable()
+class OrderItem extends Equatable {
+  const OrderItem({required this.name, required this.quantity, required this.price});
+
+  factory OrderItem.fromJson(Map<String, dynamic> json) =>
+      _$OrderItemFromJson(json);
+
+  final String name;
+  final int quantity;
+  final double price;
+
+  double get subtotal => quantity * price;
+
+  Map<String, dynamic> toJson() => _$OrderItemToJson(this);
+
+  @override
+  List<Object?> get props => [name, quantity, price];
+}

--- a/analyzers/dart/__tests__/fixtures/sample_repository.dart
+++ b/analyzers/dart/__tests__/fixtures/sample_repository.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import '../models/order_model.dart';
+
+abstract class OrderRepository {
+  Future<List<OrderModel>> findAll();
+  Future<OrderModel?> findById(String id);
+  Future<OrderModel> create({required String title, required List<String> items});
+  Future<void> delete(String id);
+}
+
+class OrderRepositoryImpl implements OrderRepository {
+  OrderRepositoryImpl({required this.apiClient});
+
+  final ApiClient apiClient;
+  final List<OrderModel> _cache = [];
+
+  @override
+  Future<List<OrderModel>> findAll() async {
+    final response = await apiClient.get('/orders');
+    final orders = (response as List).map((e) => OrderModel.fromJson(e)).toList();
+    _cache
+      ..clear()
+      ..addAll(orders);
+    return orders;
+  }
+
+  @override
+  Future<OrderModel?> findById(String id) async {
+    return _cache.where((o) => o.id == id).firstOrNull;
+  }
+
+  @override
+  Future<OrderModel> create({required String title, required List<String> items}) async {
+    final response = await apiClient.post('/orders', body: {
+      'title': title,
+      'items': items,
+    });
+    return OrderModel.fromJson(response);
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await apiClient.delete('/orders/$id');
+    _cache.removeWhere((o) => o.id == id);
+  }
+}

--- a/analyzers/dart/__tests__/fixtures/sample_widget.dart
+++ b/analyzers/dart/__tests__/fixtures/sample_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../blocs/order_bloc.dart';
+import '../models/order_model.dart';
+
+class OrderListScreen extends StatelessWidget {
+  const OrderListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<OrderBloc, OrderState>(
+      builder: (context, state) {
+        if (state is OrderLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (state is OrderLoaded) {
+          return ListView.builder(
+            itemCount: state.orders.length,
+            itemBuilder: (context, index) {
+              final order = state.orders[index];
+              return OrderTile(order: order);
+            },
+          );
+        }
+        return const Center(child: Text('No orders'));
+      },
+    );
+  }
+}
+
+class OrderTile extends StatelessWidget {
+  const OrderTile({super.key, required this.order});
+
+  final OrderModel order;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(order.title),
+      subtitle: Text(order.status.name),
+      onTap: () => Navigator.pushNamed(context, '/orders/${order.id}'),
+    );
+  }
+}

--- a/analyzers/dart/__tests__/flutter-enrichment.test.js
+++ b/analyzers/dart/__tests__/flutter-enrichment.test.js
@@ -1,0 +1,601 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { DartAnalyzer } = require('../index');
+const { enrich } = require('../flutter');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+/**
+ * Helper: read a fixture file.
+ * @param {string} filename
+ * @returns {string}
+ */
+function readFixture(filename) {
+  return fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf-8');
+}
+
+/**
+ * Helper: check if tree-sitter-dart is available.
+ * @returns {boolean}
+ */
+function isTreeSitterDartAvailable() {
+  try {
+    require('tree-sitter');
+    require('tree-sitter-dart');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const treeSitterAvailable = isTreeSitterDartAvailable();
+
+// ---------------------------------------------------------------------------
+// Tests that do NOT require tree-sitter-dart
+// (Uses manually constructed metadata objects to test enrichment logic)
+// ---------------------------------------------------------------------------
+
+describe('Flutter enrichment (no tree-sitter required)', () => {
+  it('exports an enrich function', () => {
+    assert.equal(typeof enrich, 'function');
+  });
+
+  it('returns metadata unchanged when no Flutter patterns found', () => {
+    const metadata = {
+      type: 'class',
+      name: 'PlainService',
+      inherits: null,
+      implements: [],
+      mixins: [],
+      defines: [],
+      references: [],
+    };
+    const result = enrich(metadata, null, 'class PlainService {}', 'lib/plain.dart');
+    assert.ok(!result.framework, 'Expected no framework enrichment for plain class');
+  });
+
+  it('returns metadata unchanged for null input', () => {
+    const result = enrich(null, null, '', '');
+    assert.equal(result, null);
+  });
+
+  // -----------------------------------------------------------------------
+  // Widget detection (constructed metadata)
+  // -----------------------------------------------------------------------
+
+  describe('widget detection', () => {
+    it('detects StatelessWidget from metadata', () => {
+      const metadata = {
+        type: 'class',
+        name: 'MyWidget',
+        inherits: 'StatelessWidget',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'build', type: 'method', visibility: 'public' },
+        ],
+        references: [],
+      };
+      const content = `
+class MyWidget extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}`;
+      const result = enrich(metadata, null, content, 'lib/widgets/my_widget.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_widget');
+      assert.equal(result.framework.widgetType, 'StatelessWidget');
+      assert.equal(result.framework.buildMethod, true);
+      assert.equal(result.framework.stateClass, null);
+    });
+
+    it('detects StatefulWidget and links State class', () => {
+      const metadata = {
+        type: 'class',
+        name: 'CounterPage',
+        inherits: 'StatefulWidget',
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+class CounterPage extends StatefulWidget {
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('$count');
+  }
+}`;
+      const result = enrich(metadata, null, content, 'lib/pages/counter.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_widget');
+      assert.equal(result.framework.widgetType, 'StatefulWidget');
+      assert.equal(result.framework.stateClass, '_CounterPageState');
+    });
+
+    it('detects ConsumerWidget (Riverpod)', () => {
+      const metadata = {
+        type: 'class',
+        name: 'HomeScreen',
+        inherits: 'ConsumerWidget',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'build', type: 'method', visibility: 'public' },
+        ],
+        references: [],
+      };
+      const content = `
+class HomeScreen extends ConsumerWidget {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final data = ref.watch(dataProvider);
+    return Text(data);
+  }
+}`;
+      const result = enrich(metadata, null, content, 'lib/screens/home.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_widget');
+      assert.equal(result.framework.widgetType, 'ConsumerWidget');
+    });
+
+    it('extracts BLoC dependencies from widget content', () => {
+      const metadata = {
+        type: 'class',
+        name: 'OrderScreen',
+        inherits: 'StatelessWidget',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'build', type: 'method', visibility: 'public' },
+        ],
+        references: [],
+      };
+      const content = `
+class OrderScreen extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return BlocBuilder<OrderBloc, OrderState>(
+      builder: (context, state) {
+        return Text(state.toString());
+      },
+    );
+  }
+}`;
+      const result = enrich(metadata, null, content, 'lib/screens/order.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_widget');
+      assert.ok(result.framework.dependencies.includes('OrderBloc'),
+        `Expected dependencies to include OrderBloc, got: ${JSON.stringify(result.framework.dependencies)}`);
+    });
+
+    it('extracts navigation routes from widget content', () => {
+      const metadata = {
+        type: 'class',
+        name: 'NavWidget',
+        inherits: 'StatelessWidget',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'build', type: 'method', visibility: 'public' },
+        ],
+        references: [],
+      };
+      const content = `
+class NavWidget extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () => Navigator.pushNamed(context, '/details'),
+      child: Text('Go'),
+    );
+  }
+}`;
+      const result = enrich(metadata, null, content, 'lib/widgets/nav.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.ok(result.framework.navigation.includes('/details'),
+        `Expected navigation to include /details, got: ${JSON.stringify(result.framework.navigation)}`);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BLoC detection (constructed metadata)
+  // -----------------------------------------------------------------------
+
+  describe('BLoC detection', () => {
+    it('detects BLoC class from metadata', () => {
+      const metadata = {
+        type: 'class',
+        name: 'OrderBloc',
+        inherits: 'Bloc<OrderEvent, OrderState>',
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+class OrderBloc extends Bloc<OrderEvent, OrderState> {
+  OrderBloc() : super(OrderInitial()) {
+    on<LoadOrders>(_onLoadOrders);
+    on<CreateOrder>(_onCreateOrder);
+  }
+}
+
+class LoadOrders extends OrderEvent {}
+class CreateOrder extends OrderEvent {}
+class OrderInitial extends OrderState {}
+class OrderLoading extends OrderState {}
+class OrderLoaded extends OrderState {}
+class OrderError extends OrderState {}
+`;
+      const result = enrich(metadata, null, content, 'lib/blocs/order_bloc.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_bloc');
+      assert.equal(result.framework.blocName, 'OrderBloc');
+
+      // Events
+      assert.ok(Array.isArray(result.framework.events));
+      assert.ok(result.framework.events.includes('LoadOrders'),
+        `Expected events to include LoadOrders, got: ${JSON.stringify(result.framework.events)}`);
+      assert.ok(result.framework.events.includes('CreateOrder'),
+        `Expected events to include CreateOrder, got: ${JSON.stringify(result.framework.events)}`);
+
+      // States
+      assert.ok(Array.isArray(result.framework.states));
+      assert.ok(result.framework.states.length >= 2,
+        `Expected at least 2 states, got: ${JSON.stringify(result.framework.states)}`);
+
+      // Event handlers
+      assert.ok(Array.isArray(result.framework.eventHandlers));
+      assert.ok(result.framework.eventHandlers.length >= 2,
+        `Expected at least 2 event handlers, got: ${JSON.stringify(result.framework.eventHandlers)}`);
+
+      const loadHandler = result.framework.eventHandlers.find(h => h.event === 'LoadOrders');
+      assert.ok(loadHandler, 'Expected handler for LoadOrders');
+      assert.equal(loadHandler.handler, '_onLoadOrders');
+    });
+
+    it('detects Cubit class', () => {
+      const metadata = {
+        type: 'class',
+        name: 'CounterCubit',
+        inherits: 'Cubit<int>',
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+  void increment() => emit(state + 1);
+}`;
+      const result = enrich(metadata, null, content, 'lib/cubits/counter_cubit.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_bloc');
+      assert.equal(result.framework.blocName, 'CounterCubit');
+    });
+
+    it('detects event class in bloc file', () => {
+      const metadata = {
+        type: 'class',
+        name: 'OrderEvent',
+        inherits: 'Equatable',
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+sealed class OrderEvent extends Equatable {}
+`;
+      const result = enrich(metadata, null, content, 'lib/blocs/order_bloc.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_bloc_event');
+      assert.equal(result.framework.eventName, 'OrderEvent');
+    });
+
+    it('detects state class in bloc file', () => {
+      const metadata = {
+        type: 'class',
+        name: 'OrderState',
+        inherits: 'Equatable',
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+sealed class OrderState extends Equatable {}
+`;
+      const result = enrich(metadata, null, content, 'lib/blocs/order_bloc.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_bloc_state');
+      assert.equal(result.framework.stateName, 'OrderState');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Model detection (constructed metadata)
+  // -----------------------------------------------------------------------
+
+  describe('model detection', () => {
+    it('detects model with JSON serialization', () => {
+      const metadata = {
+        type: 'class',
+        name: 'UserModel',
+        inherits: 'Equatable',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'UserModel.fromJson', type: 'constructor', named: true, factory: true, const: false },
+          { name: 'toJson', type: 'method', visibility: 'public' },
+          { name: 'id', type: 'field', fieldType: 'String', final: true },
+          { name: 'name', type: 'field', fieldType: 'String', final: true },
+        ],
+        references: [],
+      };
+      const content = `
+@JsonSerializable()
+class UserModel extends Equatable {
+  const UserModel({required this.id, required this.name});
+  factory UserModel.fromJson(Map<String, dynamic> json) => _$UserModelFromJson(json);
+  final String id;
+  final String name;
+  Map<String, dynamic> toJson() => _$UserModelToJson(this);
+  @override
+  List<Object?> get props => [id, name];
+}`;
+      const result = enrich(metadata, null, content, 'lib/models/user_model.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_model');
+      assert.equal(result.framework.serializable, true);
+      assert.equal(result.framework.equatable, true);
+    });
+
+    it('detects freezed model', () => {
+      const metadata = {
+        type: 'class',
+        name: 'User',
+        inherits: null,
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = `
+@freezed
+class User with _$User {
+  const factory User({required String name}) = _User;
+}`;
+      const result = enrich(metadata, null, content, 'lib/models/user.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_model');
+      assert.equal(result.framework.freezed, true);
+    });
+
+    it('detects copyWith method', () => {
+      const metadata = {
+        type: 'class',
+        name: 'Config',
+        inherits: null,
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'copyWith', type: 'method', visibility: 'public' },
+          { name: 'value', type: 'field', fieldType: 'int', final: true },
+        ],
+        references: [],
+      };
+      const content = `
+class Config {
+  const Config({required this.value});
+  final int value;
+  Config copyWith({int? value}) => Config(value: value ?? this.value);
+  factory Config.fromJson(Map<String, dynamic> json) => Config(value: json['value']);
+}`;
+      const result = enrich(metadata, null, content, 'lib/models/config.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.equal(result.framework.type, 'flutter_model');
+      assert.equal(result.framework.copyWith, true);
+      assert.equal(result.framework.serializable, true);
+    });
+
+    it('extracts fields from model metadata', () => {
+      const metadata = {
+        type: 'class',
+        name: 'Product',
+        inherits: 'Equatable',
+        implements: [],
+        mixins: [],
+        defines: [
+          { name: 'id', type: 'field', fieldType: 'String', final: true },
+          { name: 'price', type: 'field', fieldType: 'double', final: true },
+          { name: 'save', type: 'method', visibility: 'public' },
+        ],
+        references: [],
+      };
+      const content = `
+class Product extends Equatable {
+  final String id;
+  final double price;
+  Map<String, dynamic> toJson() => {};
+  @override
+  List<Object?> get props => [id, price];
+}`;
+      const result = enrich(metadata, null, content, 'lib/models/product.dart');
+      assert.ok(result.framework, 'Expected framework enrichment');
+      assert.ok(Array.isArray(result.framework.fields));
+      assert.equal(result.framework.fields.length, 2);
+      assert.ok(result.framework.fields.some(f => f.name === 'id'));
+      assert.ok(result.framework.fields.some(f => f.name === 'price'));
+    });
+
+    it('does not detect model for non-model classes', () => {
+      const metadata = {
+        type: 'class',
+        name: 'MyService',
+        inherits: null,
+        implements: [],
+        mixins: [],
+        defines: [],
+        references: [],
+      };
+      const content = 'class MyService {}';
+      const result = enrich(metadata, null, content, 'lib/services/my_service.dart');
+      assert.ok(!result.framework, 'Expected no framework enrichment for a plain service class');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests using tree-sitter-dart + enrichment
+// ---------------------------------------------------------------------------
+
+describe('Flutter enrichment (integration, tree-sitter required)', { skip: !treeSitterAvailable && 'tree-sitter-dart not installed' }, () => {
+  let analyzer;
+
+  beforeEach(() => {
+    analyzer = new DartAnalyzer();
+  });
+
+  describe('sample_widget.dart', () => {
+    it('enriches widget metadata from parsed fixture', () => {
+      const content = readFixture('sample_widget.dart');
+      const filePath = 'lib/screens/sample_widget.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderListScreen = results.find(r => r.name === 'OrderListScreen');
+      assert.ok(orderListScreen, 'Expected to find OrderListScreen');
+
+      const enriched = enrich(orderListScreen, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_widget');
+      assert.equal(enriched.framework.widgetType, 'StatelessWidget');
+
+      // Should detect BLoC dependency
+      assert.ok(enriched.framework.dependencies.includes('OrderBloc'),
+        `Expected OrderBloc in dependencies, got: ${JSON.stringify(enriched.framework.dependencies)}`);
+    });
+
+    it('detects navigation in OrderTile', () => {
+      const content = readFixture('sample_widget.dart');
+      const filePath = 'lib/screens/sample_widget.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderTile = results.find(r => r.name === 'OrderTile');
+      assert.ok(orderTile, 'Expected to find OrderTile');
+
+      const enriched = enrich(orderTile, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.ok(enriched.framework.navigation.length > 0,
+        'Expected at least one navigation route');
+    });
+  });
+
+  describe('sample_bloc.dart', () => {
+    it('enriches BLoC metadata from parsed fixture', () => {
+      const content = readFixture('sample_bloc.dart');
+      const filePath = 'lib/blocs/sample_bloc.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderBloc = results.find(r => r.name === 'OrderBloc');
+      assert.ok(orderBloc, 'Expected to find OrderBloc');
+
+      const enriched = enrich(orderBloc, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_bloc');
+      assert.equal(enriched.framework.blocName, 'OrderBloc');
+
+      // Should extract events
+      assert.ok(enriched.framework.events.includes('LoadOrders'),
+        `Expected LoadOrders in events, got: ${JSON.stringify(enriched.framework.events)}`);
+      assert.ok(enriched.framework.events.includes('CreateOrder'),
+        `Expected CreateOrder in events, got: ${JSON.stringify(enriched.framework.events)}`);
+
+      // Should extract states
+      assert.ok(enriched.framework.states.length >= 2,
+        `Expected at least 2 states, got: ${JSON.stringify(enriched.framework.states)}`);
+
+      // Should extract event handlers
+      assert.ok(enriched.framework.eventHandlers.length >= 2,
+        `Expected at least 2 handlers, got: ${JSON.stringify(enriched.framework.eventHandlers)}`);
+    });
+
+    it('enriches event class in bloc file', () => {
+      const content = readFixture('sample_bloc.dart');
+      const filePath = 'lib/blocs/sample_bloc.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderEvent = results.find(r => r.name === 'OrderEvent');
+      assert.ok(orderEvent, 'Expected to find OrderEvent');
+
+      const enriched = enrich(orderEvent, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_bloc_event');
+    });
+
+    it('enriches state class in bloc file', () => {
+      const content = readFixture('sample_bloc.dart');
+      const filePath = 'lib/blocs/sample_bloc.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderState = results.find(r => r.name === 'OrderState');
+      assert.ok(orderState, 'Expected to find OrderState');
+
+      const enriched = enrich(orderState, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_bloc_state');
+    });
+  });
+
+  describe('sample_model.dart', () => {
+    it('enriches model metadata from parsed fixture', () => {
+      const content = readFixture('sample_model.dart');
+      const filePath = 'lib/models/sample_model.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderModel = results.find(r => r.name === 'OrderModel');
+      assert.ok(orderModel, 'Expected to find OrderModel');
+
+      const enriched = enrich(orderModel, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_model');
+      assert.equal(enriched.framework.serializable, true);
+      assert.equal(enriched.framework.equatable, true);
+      assert.equal(enriched.framework.copyWith, true);
+      assert.equal(enriched.framework.freezed, false);
+    });
+
+    it('detects OrderItem as a model too', () => {
+      const content = readFixture('sample_model.dart');
+      const filePath = 'lib/models/sample_model.dart';
+      const tree = analyzer.parse(filePath, content);
+      const results = analyzer.extractMetadata(tree, filePath, content);
+
+      const orderItem = results.find(r => r.name === 'OrderItem');
+      assert.ok(orderItem, 'Expected to find OrderItem');
+
+      const enriched = enrich(orderItem, tree, content, filePath);
+      assert.ok(enriched.framework, 'Expected framework enrichment');
+      assert.equal(enriched.framework.type, 'flutter_model');
+      assert.equal(enriched.framework.serializable, true);
+    });
+  });
+});

--- a/analyzers/dart/flutter.js
+++ b/analyzers/dart/flutter.js
@@ -1,0 +1,526 @@
+'use strict';
+
+/**
+ * Flutter enrichment layer for the Dart analyzer.
+ *
+ * Detects Flutter-specific patterns by analyzing AST and content:
+ * - Widgets: StatelessWidget, StatefulWidget, HookWidget, ConsumerWidget
+ * - State management: BLoC, Riverpod, Provider
+ * - Navigation: Navigator, GoRouter
+ * - Models: JSON serialization, Equatable, Freezed
+ *
+ * Uses a combination of AST analysis and regex-based content detection
+ * because many Flutter patterns (e.g., BlocBuilder<X, Y>) are easier
+ * to detect via text matching than via tree-sitter node types.
+ */
+
+// Known Flutter widget base classes
+const WIDGET_BASES = new Set([
+  'StatelessWidget', 'StatefulWidget',
+  'HookWidget', 'HookConsumerWidget',
+  'ConsumerWidget', 'ConsumerStatefulWidget',
+]);
+
+// Known State base pattern: State<WidgetName>
+const STATE_BASE_PATTERN = /\bState<(\w+)>/;
+
+// BLoC base classes
+const BLOC_BASES = new Set([
+  'Bloc', 'Cubit',
+]);
+
+// BLoC widget patterns (content-based detection)
+const BLOC_WIDGET_PATTERNS = [
+  /BlocProvider\s*</,
+  /BlocBuilder\s*<\s*(\w+)\s*,\s*(\w+)\s*>/,
+  /BlocListener\s*<\s*(\w+)\s*,\s*(\w+)\s*>/,
+  /BlocConsumer\s*<\s*(\w+)\s*,\s*(\w+)\s*>/,
+  /MultiBlocProvider/,
+  /MultiBlocListener/,
+];
+
+// Navigation patterns
+const NAVIGATION_PATTERNS = [
+  /Navigator\s*\.\s*push(?:Named|Replacement|AndRemoveUntil)?\s*\(\s*\w*\s*,?\s*['"]([^'"]*)['"]/g,
+  /Navigator\s*\.\s*pop\b/g,
+  /context\s*\.\s*(?:go|push|pushNamed|pushReplacement)\s*\(\s*['"]([^'"]*)['"]/g,
+  /GoRouter\s*\.\s*of\s*\(/g,
+];
+
+// Riverpod patterns
+const RIVERPOD_PATTERNS = [
+  /ref\s*\.\s*watch\s*\(/,
+  /ref\s*\.\s*read\s*\(/,
+  /ref\s*\.\s*listen\s*\(/,
+  /(?:State|StateNotifier|ChangeNotifier|AsyncNotifier)Provider/,
+  /ConsumerWidget/,
+  /ConsumerStatefulWidget/,
+  /HookConsumerWidget/,
+];
+
+// Provider patterns (classic)
+const PROVIDER_PATTERNS = [
+  /Provider\s*\.\s*of\s*<\s*(\w+)\s*>\s*\(/,
+  /Consumer\s*<\s*(\w+)\s*>/,
+  /ChangeNotifierProvider/,
+  /MultiProvider/,
+];
+
+/**
+ * Enrich metadata with Flutter-specific information.
+ * @param {object} metadata - Base metadata from DartAnalyzer.extractMetadata()
+ *   (a single metadata entry, not the array)
+ * @param {object} tree - tree-sitter parse tree (may be null)
+ * @param {string} content - Raw file content
+ * @param {string} filePath - File path for context
+ * @returns {object} Enriched metadata (same object, mutated)
+ */
+function enrich(metadata, tree, content, filePath) {
+  if (!metadata || !content) return metadata;
+
+  try {
+    // Detect widget patterns
+    const widgetInfo = detectWidget(metadata, content, filePath);
+    if (widgetInfo) {
+      metadata.framework = widgetInfo;
+      return metadata;
+    }
+
+    // Detect BLoC patterns
+    const blocInfo = detectBloc(metadata, content, filePath);
+    if (blocInfo) {
+      metadata.framework = blocInfo;
+      return metadata;
+    }
+
+    // Detect model patterns
+    const modelInfo = detectModel(metadata, content, filePath);
+    if (modelInfo) {
+      metadata.framework = modelInfo;
+      return metadata;
+    }
+  } catch (err) {
+    // Enrichment should never break the pipeline
+  }
+
+  return metadata;
+}
+
+// ---------------------------------------------------------------------------
+// Widget detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect if this metadata represents a Flutter widget.
+ * @param {object} metadata
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {object|null}
+ */
+function detectWidget(metadata, content, filePath) {
+  if (metadata.type !== 'class') return null;
+
+  const inherits = metadata.inherits;
+  if (!inherits) return null;
+
+  // Check if the class extends a known widget base
+  const baseClass = cleanGenericType(inherits);
+  if (!WIDGET_BASES.has(baseClass)) return null;
+
+  const widgetType = baseClass;
+  const result = {
+    type: 'flutter_widget',
+    widgetType,
+    stateClass: null,
+    dependencies: [],
+    navigation: [],
+    buildMethod: false,
+  };
+
+  // Check for build method
+  if (metadata.defines) {
+    const hasBuild = metadata.defines.some(d => d.type === 'method' && d.name === 'build');
+    result.buildMethod = hasBuild;
+  }
+
+  // For StatefulWidget, find the associated State class
+  if (widgetType === 'StatefulWidget' || widgetType === 'ConsumerStatefulWidget') {
+    result.stateClass = findStateClass(metadata.name, content);
+  }
+
+  // Extract widget dependencies from BLoC usage
+  result.dependencies = extractWidgetDependencies(content);
+
+  // Extract navigation routes
+  result.navigation = extractNavigationRoutes(content);
+
+  return result;
+}
+
+/**
+ * Find the State class associated with a StatefulWidget.
+ * Conventions: _WidgetNameState or WidgetNameState
+ * @param {string} widgetName
+ * @param {string} content
+ * @returns {string|null}
+ */
+function findStateClass(widgetName, content) {
+  // Look for class _WidgetNameState extends State<WidgetName>
+  const privatePattern = new RegExp(`class\\s+(_${widgetName}State)\\s+extends\\s+State<${widgetName}>`);
+  const publicPattern = new RegExp(`class\\s+(${widgetName}State)\\s+extends\\s+State<${widgetName}>`);
+
+  const privateMatch = content.match(privatePattern);
+  if (privateMatch) return privateMatch[1];
+
+  const publicMatch = content.match(publicPattern);
+  if (publicMatch) return publicMatch[1];
+
+  // Generic pattern: any class extending State<WidgetName>
+  const genericPattern = new RegExp(`class\\s+(\\w+)\\s+extends\\s+State<${widgetName}>`);
+  const genericMatch = content.match(genericPattern);
+  if (genericMatch) return genericMatch[1];
+
+  return null;
+}
+
+/**
+ * Extract widget dependencies from BLoC/Provider/Riverpod usage in content.
+ * @param {string} content
+ * @returns {string[]}
+ */
+function extractWidgetDependencies(content) {
+  const deps = new Set();
+
+  // BlocBuilder<BlocName, StateName>
+  const blocBuilderPattern = /Bloc(?:Builder|Listener|Consumer)\s*<\s*(\w+)\s*,/g;
+  let match;
+  while ((match = blocBuilderPattern.exec(content)) !== null) {
+    deps.add(match[1]);
+  }
+
+  // BlocProvider.of<BlocName>(context)
+  const blocProviderPattern = /BlocProvider\s*\.\s*of\s*<\s*(\w+)\s*>/g;
+  while ((match = blocProviderPattern.exec(content)) !== null) {
+    deps.add(match[1]);
+  }
+
+  // context.read<BlocName>() / context.watch<BlocName>()
+  const contextPattern = /context\s*\.\s*(?:read|watch)\s*<\s*(\w+)\s*>/g;
+  while ((match = contextPattern.exec(content)) !== null) {
+    deps.add(match[1]);
+  }
+
+  // Provider.of<T>(context)
+  const providerOfPattern = /Provider\s*\.\s*of\s*<\s*(\w+)\s*>/g;
+  while ((match = providerOfPattern.exec(content)) !== null) {
+    deps.add(match[1]);
+  }
+
+  // ref.watch(someProvider) / ref.read(someProvider)
+  const refPattern = /ref\s*\.\s*(?:watch|read|listen)\s*\(\s*(\w+)/g;
+  while ((match = refPattern.exec(content)) !== null) {
+    deps.add(match[1]);
+  }
+
+  return [...deps];
+}
+
+/**
+ * Extract navigation route strings from content.
+ * @param {string} content
+ * @returns {string[]}
+ */
+function extractNavigationRoutes(content) {
+  const routes = new Set();
+
+  // Navigator.pushNamed(context, '/path')
+  const pushNamedPattern = /Navigator\s*\.\s*pushNamed\s*\(\s*\w+\s*,\s*['"]([^'"]*)['"]/g;
+  let match;
+  while ((match = pushNamedPattern.exec(content)) !== null) {
+    routes.add(match[1]);
+  }
+
+  // Navigator.push with MaterialPageRoute — harder to extract route, skip
+  // context.go('/path'), context.push('/path')
+  const goRouterPattern = /context\s*\.\s*(?:go|push|pushNamed|pushReplacement)\s*\(\s*['"]([^'"]*)['"]/g;
+  while ((match = goRouterPattern.exec(content)) !== null) {
+    routes.add(match[1]);
+  }
+
+  // Interpolated strings: '/orders/${order.id}' — capture the template
+  const interpPattern = /(?:Navigator\s*\.\s*pushNamed|context\s*\.\s*(?:go|push))\s*\(\s*(?:\w+\s*,\s*)?['"]([^'"]*\$\{[^}]+\}[^'"]*)['"]/g;
+  while ((match = interpPattern.exec(content)) !== null) {
+    routes.add(match[1]);
+  }
+
+  // Also match string interpolation style used in Dart
+  const dartInterpPattern = /(?:Navigator\s*\.\s*pushNamed|context\s*\.\s*(?:go|push))\s*\(\s*(?:\w+\s*,\s*)?'([^']*\$[^']*)'|"([^"]*\$[^"]*)"/g;
+  while ((match = dartInterpPattern.exec(content)) !== null) {
+    const route = match[1] || match[2];
+    if (route) routes.add(route);
+  }
+
+  return [...routes];
+}
+
+// ---------------------------------------------------------------------------
+// BLoC detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect if this metadata represents a BLoC/Cubit pattern.
+ * Also detects BLoC events and states (sealed/abstract classes in bloc files).
+ * @param {object} metadata
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {object|null}
+ */
+function detectBloc(metadata, content, filePath) {
+  if (metadata.type !== 'class') return null;
+
+  const inherits = metadata.inherits;
+  const normalizedPath = (filePath || '').replace(/\\/g, '/');
+  const isBlocFile = normalizedPath.includes('_bloc.dart') ||
+                     normalizedPath.includes('_cubit.dart') ||
+                     normalizedPath.includes('/blocs/') ||
+                     normalizedPath.includes('/bloc/') ||
+                     normalizedPath.includes('/cubits/');
+
+  // Check if the class extends Bloc or Cubit
+  if (inherits) {
+    const baseClass = cleanGenericType(inherits);
+    if (BLOC_BASES.has(baseClass)) {
+      return buildBlocFrameworkInfo(metadata, content, inherits);
+    }
+  }
+
+  // If we're in a bloc file, check for event/state base classes
+  if (isBlocFile) {
+    // Check for sealed/abstract classes that look like events or states
+    const isEvent = isEventClass(metadata, content);
+    const isState = isStateClass(metadata, content);
+
+    if (isEvent) {
+      return {
+        type: 'flutter_bloc_event',
+        eventName: metadata.name,
+        fields: extractClassFields(metadata),
+      };
+    }
+
+    if (isState) {
+      return {
+        type: 'flutter_bloc_state',
+        stateName: metadata.name,
+        fields: extractClassFields(metadata),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build BLoC framework info for a class extending Bloc<Event, State>.
+ * @param {object} metadata
+ * @param {string} content
+ * @param {string} inherits
+ * @returns {object}
+ */
+function buildBlocFrameworkInfo(metadata, content, inherits) {
+  // Extract event and state types from Bloc<EventType, StateType>
+  const genericMatch = inherits.match(/(?:Bloc|Cubit)\s*<\s*(\w+)\s*(?:,\s*(\w+))?\s*>/);
+  const eventType = genericMatch ? genericMatch[1] : null;
+  const stateType = genericMatch ? (genericMatch[2] || genericMatch[1]) : null;
+
+  // Extract events (subclasses of the event type)
+  const events = extractSubclasses(content, eventType);
+
+  // Extract states (subclasses of the state type)
+  const states = extractSubclasses(content, stateType);
+
+  // Extract event handlers: on<EventName>(_handler)
+  const eventHandlers = extractEventHandlers(content);
+
+  return {
+    type: 'flutter_bloc',
+    blocName: metadata.name,
+    events,
+    states,
+    eventHandlers,
+  };
+}
+
+/**
+ * Check if a class looks like a BLoC event base class.
+ * @param {object} metadata
+ * @param {string} content
+ * @returns {boolean}
+ */
+function isEventClass(metadata, content) {
+  const name = metadata.name;
+  // Common patterns: ends with Event, is abstract/sealed, extends Equatable
+  if (/Event$/.test(name)) return true;
+
+  // Check if the content has "sealed class X extends ... Event"
+  const sealedPattern = new RegExp(`sealed\\s+class\\s+${escapeRegex(name)}\\b`);
+  if (sealedPattern.test(content) && /Event/.test(name)) return true;
+
+  return false;
+}
+
+/**
+ * Check if a class looks like a BLoC state base class.
+ * @param {object} metadata
+ * @param {string} content
+ * @returns {boolean}
+ */
+function isStateClass(metadata, content) {
+  const name = metadata.name;
+  if (/State$/.test(name) && !/StatefulWidget|StatelessWidget/.test(name)) return true;
+
+  const sealedPattern = new RegExp(`sealed\\s+class\\s+${escapeRegex(name)}\\b`);
+  if (sealedPattern.test(content) && /State/.test(name)) return true;
+
+  return false;
+}
+
+/**
+ * Extract event handler registrations from BLoC constructor.
+ * Pattern: on<EventName>(_handlerMethod);
+ * @param {string} content
+ * @returns {Array<{event: string, handler: string}>}
+ */
+function extractEventHandlers(content) {
+  const handlers = [];
+  const pattern = /on\s*<\s*(\w+)\s*>\s*\(\s*(\w+)\s*\)/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    handlers.push({
+      event: match[1],
+      handler: match[2],
+    });
+  }
+  return handlers;
+}
+
+/**
+ * Extract subclasses of a given base class from the file content.
+ * @param {string} content
+ * @param {string} baseClassName
+ * @returns {string[]}
+ */
+function extractSubclasses(content, baseClassName) {
+  if (!baseClassName) return [];
+  const subclasses = [];
+  const pattern = new RegExp(`class\\s+(\\w+)\\s+extends\\s+${escapeRegex(baseClassName)}\\b`, 'g');
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    subclasses.push(match[1]);
+  }
+  return subclasses;
+}
+
+/**
+ * Extract field info from metadata defines.
+ * @param {object} metadata
+ * @returns {Array<{name: string, type: string|null, final: boolean}>}
+ */
+function extractClassFields(metadata) {
+  if (!metadata.defines) return [];
+  return metadata.defines
+    .filter(d => d.type === 'field')
+    .map(d => ({
+      name: d.name,
+      type: d.fieldType || null,
+      final: d.final || false,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Model detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect if this metadata represents a Flutter model/entity class.
+ * @param {object} metadata
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {object|null}
+ */
+function detectModel(metadata, content, filePath) {
+  if (metadata.type !== 'class') return null;
+
+  const normalizedPath = (filePath || '').replace(/\\/g, '/');
+  const isModelFile = normalizedPath.includes('/models/') ||
+                      normalizedPath.includes('/entities/') ||
+                      normalizedPath.includes('_model.dart') ||
+                      normalizedPath.includes('_entity.dart');
+
+  // Check for model indicators
+  const hasFromJson = hasMethod(metadata, 'fromJson') || /\bfromJson\b/.test(content);
+  const hasToJson = hasMethod(metadata, 'toJson') || /\btoJson\b/.test(content);
+  const hasJsonSerializable = /@JsonSerializable\b/.test(content);
+  const hasEquatable = metadata.inherits === 'Equatable' ||
+                       (metadata.mixins && metadata.mixins.includes('EquatableMixin'));
+  const hasFreezed = /@freezed\b/.test(content) || /@Freezed\b/.test(content);
+  const hasCopyWith = hasMethod(metadata, 'copyWith') || /\bcopyWith\b/.test(content);
+  const hasPropsGetter = /\bList<Object\??>?\s+get\s+props\b/.test(content);
+
+  const isSerializable = hasFromJson || hasToJson || hasJsonSerializable;
+  const isModel = isSerializable || hasEquatable || hasFreezed || isModelFile;
+
+  if (!isModel) return null;
+
+  // Extract fields
+  const fields = extractClassFields(metadata);
+
+  return {
+    type: 'flutter_model',
+    serializable: isSerializable,
+    freezed: hasFreezed,
+    equatable: hasEquatable || hasPropsGetter,
+    copyWith: hasCopyWith,
+    fields,
+  };
+}
+
+/**
+ * Check if metadata defines contain a method or constructor with the given name.
+ * @param {object} metadata
+ * @param {string} methodName
+ * @returns {boolean}
+ */
+function hasMethod(metadata, methodName) {
+  if (!metadata.defines) return false;
+  return metadata.defines.some(d =>
+    (d.type === 'method' || d.type === 'constructor') &&
+    (d.name === methodName || d.name.endsWith(`.${methodName}`))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove generic type arguments from a type string.
+ * e.g., "Bloc<OrderEvent, OrderState>" => "Bloc"
+ * @param {string} typeStr
+ * @returns {string}
+ */
+function cleanGenericType(typeStr) {
+  if (!typeStr) return '';
+  return typeStr.replace(/<[^>]*>/, '').trim();
+}
+
+/**
+ * Escape a string for use in a regex.
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { enrich };

--- a/analyzers/dart/index.js
+++ b/analyzers/dart/index.js
@@ -1,0 +1,1627 @@
+'use strict';
+
+const path = require('path');
+const { BaseAnalyzer } = require('../base-analyzer');
+const { loadParser } = require('../shared/tree-sitter-loader');
+
+/**
+ * Dart language analyzer.
+ * Uses tree-sitter-dart to parse Dart source files and extract semantic metadata.
+ *
+ * Extracts: classes, mixins, extensions, enums, functions, methods, constructors,
+ * fields, imports, exports, typedefs, and generics.
+ *
+ * Dart visibility: underscore prefix (_) = private; no underscore = public.
+ *
+ * NOTE: tree-sitter-dart is community-maintained. Node type names may vary between
+ * grammar versions. This analyzer is intentionally defensive — it uses helpers that
+ * check for multiple possible node type names and falls back to regex-based
+ * extraction when AST nodes are unavailable.
+ */
+class DartAnalyzer extends BaseAnalyzer {
+  /**
+   * Parse Dart source code into a tree-sitter AST.
+   * @param {string} filePath - Path to the file
+   * @param {string} content - Raw file content
+   * @returns {object|null} Parsed tree-sitter tree, or null if parsing fails
+   */
+  parse(filePath, content) {
+    const loaded = loadParser('dart');
+    if (!loaded) return null;
+
+    try {
+      const tree = loaded.parser.parse(content);
+      return tree;
+    } catch (err) {
+      console.warn(`[dart-analyzer] Failed to parse ${filePath}: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Extract semantic metadata from a parsed Dart AST.
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} filePath - Path for context
+   * @param {string} content - Raw content
+   * @returns {Array<object>} Array of metadata objects (one per top-level definition)
+   */
+  extractMetadata(tree, filePath, content) {
+    const rootNode = tree.rootNode;
+    const scope = this._deriveScope(filePath);
+    const imports = this._extractImports(rootNode, content);
+    const exports = this._extractExports(rootNode, content);
+    const results = [];
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const child = rootNode.child(i);
+      try {
+        const meta = this._extractTopLevelNode(child, content, scope, imports);
+        if (meta) {
+          results.push(meta);
+        }
+      } catch (err) {
+        // Defensive: skip nodes that cause errors
+        continue;
+      }
+    }
+
+    // If no top-level definitions were extracted, return a file-level metadata object
+    if (results.length === 0) {
+      return [this._buildFileLevelMetadata(filePath, scope, imports, exports, rootNode, content)];
+    }
+
+    // Attach imports and exports to the first (primary) definition
+    if (results.length > 0) {
+      results[0].imports = imports;
+      results[0].exports = exports;
+    }
+
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Top-level node dispatch
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from a single top-level AST node.
+   * @param {object} node - tree-sitter node
+   * @param {string} content - source content
+   * @param {string[]} scope - derived scope
+   * @param {Array<object>} imports - file-level imports
+   * @returns {object|null} metadata or null if not a recognized definition
+   */
+  _extractTopLevelNode(node, content, scope, imports) {
+    const type = node.type;
+
+    // Classes (including abstract)
+    if (this._isNodeType(type, ['class_definition', 'class_declaration'])) {
+      return this._extractClass(node, content, scope);
+    }
+
+    // Mixins
+    if (this._isNodeType(type, ['mixin_declaration', 'mixin_definition'])) {
+      return this._extractMixin(node, content, scope);
+    }
+
+    // Extensions
+    if (this._isNodeType(type, ['extension_declaration', 'extension_definition'])) {
+      return this._extractExtension(node, content, scope);
+    }
+
+    // Enums
+    if (this._isNodeType(type, ['enum_declaration', 'enum_definition'])) {
+      return this._extractEnum(node, content, scope);
+    }
+
+    // Top-level functions
+    if (this._isNodeType(type, [
+      'function_definition', 'function_declaration',
+      'function_signature', 'function_body',
+      'top_level_definition',
+    ])) {
+      return this._extractFunction(node, content, scope);
+    }
+
+    // Typedefs
+    if (this._isNodeType(type, ['type_alias', 'typedef', 'type_alias_declaration'])) {
+      return this._extractTypedef(node, content, scope);
+    }
+
+    // Some grammars wrap top-level declarations
+    if (this._isNodeType(type, ['declaration', 'top_level_definition'])) {
+      // Recurse into the child
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        const result = this._extractTopLevelNode(child, content, scope, imports);
+        if (result) return result;
+      }
+    }
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Class extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from a class definition node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractClass(node, content, scope) {
+    const text = this._nodeText(node, content);
+    const name = this._extractClassName(node, content, text);
+    const isAbstract = this._isAbstractClass(node, content, text);
+    const inherits = this._extractSuperclass(node, content, text);
+    const implementsList = this._extractImplements(node, content, text);
+    const mixinsList = this._extractMixins(node, content, text);
+    const typeParams = this._extractTypeParameters(node, content, text);
+    const defines = [];
+    const references = [];
+
+    // Collect references from superclass, implements, mixins
+    if (inherits) references.push(inherits);
+    references.push(...implementsList);
+    references.push(...mixinsList);
+
+    // Extract body contents (methods, constructors, fields)
+    this._extractClassBody(node, content, name, defines, references);
+
+    return {
+      type: 'class',
+      name,
+      abstract: isAbstract,
+      exported: !name.startsWith('_'),
+      inherits: inherits || null,
+      implements: implementsList,
+      mixins: mixinsList,
+      typeParameters: typeParams.length > 0 ? typeParams : undefined,
+      scope,
+      defines,
+      references: [...new Set(references)],
+      imports: [],
+    };
+  }
+
+  /**
+   * Extract the class name from a node or text.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string}
+   */
+  _extractClassName(node, content, text) {
+    // Try field-based extraction first
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+
+    // Try finding first type_identifier or identifier child
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        return this._nodeText(child, content);
+      }
+    }
+
+    // Fallback: regex on text
+    const match = text.match(/(?:abstract\s+)?class\s+(\w+)/);
+    return match ? match[1] : 'Unknown';
+  }
+
+  /**
+   * Determine if a class is abstract.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {boolean}
+   */
+  _isAbstractClass(node, content, text) {
+    // Some grammars have 'abstract' as a child keyword node
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      const childText = this._nodeText(child, content);
+      if (childText === 'abstract') return true;
+    }
+    // Fallback: check the text
+    return /^\s*abstract\s+class\b/.test(text);
+  }
+
+  /**
+   * Extract the superclass from a class definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string|null}
+   */
+  _extractSuperclass(node, content, text) {
+    // Try field-based
+    const superNode = node.childForFieldName('superclass');
+    if (superNode) return this._cleanTypeName(this._nodeText(superNode, content));
+
+    // Try looking for extends clause child
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['superclass', 'extends_clause', 'superclass_clause'])) {
+        // Get the type from this clause
+        const typeNode = this._findTypeInNode(child, content);
+        if (typeNode) return this._cleanTypeName(typeNode);
+      }
+    }
+
+    // Fallback: regex
+    const match = text.match(/\bextends\s+([\w<>,\s?]+?)(?:\s+(?:implements|with|{)|\s*\{)/);
+    if (match) return this._cleanTypeName(match[1].trim());
+
+    return null;
+  }
+
+  /**
+   * Extract implements list from a class definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _extractImplements(node, content, text) {
+    // Try field or child node
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['interfaces', 'implements_clause', 'interface_type_list'])) {
+        return this._extractTypeList(child, content);
+      }
+    }
+
+    // Fallback: regex
+    const match = text.match(/\bimplements\s+([\w<>,\s?]+?)(?:\s+(?:with|{)|\s*\{)/);
+    if (match) {
+      return match[1].split(',').map(s => this._cleanTypeName(s.trim())).filter(Boolean);
+    }
+    return [];
+  }
+
+  /**
+   * Extract mixin (with clause) list from a class definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _extractMixins(node, content, text) {
+    // Try child node
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['mixins', 'with_clause', 'mixin_application'])) {
+        return this._extractTypeList(child, content);
+      }
+    }
+
+    // Fallback: regex
+    const match = text.match(/\bwith\s+([\w<>,\s?]+?)(?:\s+(?:implements|{)|\s*\{)/);
+    if (match) {
+      return match[1].split(',').map(s => this._cleanTypeName(s.trim())).filter(Boolean);
+    }
+    return [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mixin extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from a mixin declaration node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractMixin(node, content, scope) {
+    const text = this._nodeText(node, content);
+    const name = this._extractMixinName(node, content, text);
+    const onConstraints = this._extractOnConstraints(node, content, text);
+    const implementsList = this._extractImplements(node, content, text);
+    const defines = [];
+    const references = [...onConstraints, ...implementsList];
+
+    this._extractClassBody(node, content, name, defines, references);
+
+    return {
+      type: 'mixin',
+      name,
+      exported: !name.startsWith('_'),
+      on: onConstraints,
+      implements: implementsList,
+      scope,
+      defines,
+      references: [...new Set(references)],
+      imports: [],
+    };
+  }
+
+  /**
+   * Extract the mixin name.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string}
+   */
+  _extractMixinName(node, content, text) {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        return this._nodeText(child, content);
+      }
+    }
+
+    const match = text.match(/\bmixin\s+(\w+)/);
+    return match ? match[1] : 'Unknown';
+  }
+
+  /**
+   * Extract 'on' constraints from a mixin declaration.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _extractOnConstraints(node, content, text) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['on_clause', 'superclass_constraint', 'on_interfaces'])) {
+        return this._extractTypeList(child, content);
+      }
+    }
+
+    const match = text.match(/\bon\s+([\w<>,\s?]+?)(?:\s+(?:implements|{)|\s*\{)/);
+    if (match) {
+      return match[1].split(',').map(s => this._cleanTypeName(s.trim())).filter(Boolean);
+    }
+    return [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extension extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from an extension declaration node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractExtension(node, content, scope) {
+    const text = this._nodeText(node, content);
+    const name = this._extractExtensionName(node, content, text);
+    const onType = this._extractExtensionOnType(node, content, text);
+    const defines = [];
+    const references = [];
+
+    if (onType) references.push(this._cleanTypeName(onType));
+
+    this._extractClassBody(node, content, name, defines, references);
+
+    return {
+      type: 'extension',
+      name,
+      exported: !name.startsWith('_'),
+      on: onType,
+      scope,
+      defines,
+      references: [...new Set(references)],
+      imports: [],
+    };
+  }
+
+  /**
+   * Extract the extension name.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string}
+   */
+  _extractExtensionName(node, content, text) {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        const val = this._nodeText(child, content);
+        if (val !== 'extension' && val !== 'on') return val;
+      }
+    }
+
+    const match = text.match(/\bextension\s+(\w+)/);
+    return match ? match[1] : 'UnnamedExtension';
+  }
+
+  /**
+   * Extract the 'on' type from an extension.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string|null}
+   */
+  _extractExtensionOnType(node, content, text) {
+    // Try child node approach
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['on_clause', 'type_identifier'])) {
+        // For on_clause, find the type inside
+        if (child.type === 'type_identifier') {
+          // Skip the name identifier — look for the one after 'on'
+          continue;
+        }
+        const typeText = this._findTypeInNode(child, content);
+        if (typeText) return typeText;
+      }
+    }
+
+    // Fallback: regex
+    const match = text.match(/\bon\s+([\w<>,\s?]+?)(?:\s*\{)/);
+    if (match) return match[1].trim();
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enum extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from an enum declaration node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractEnum(node, content, scope) {
+    const text = this._nodeText(node, content);
+    const name = this._extractEnumName(node, content, text);
+    const members = this._extractEnumMembers(node, content, text);
+    const defines = [];
+    const references = [];
+
+    // Check for enhanced enum (methods/fields inside)
+    this._extractClassBody(node, content, name, defines, references);
+
+    return {
+      type: 'enum',
+      name,
+      exported: !name.startsWith('_'),
+      members,
+      scope,
+      defines,
+      references: [...new Set(references)],
+      imports: [],
+    };
+  }
+
+  /**
+   * Extract enum name.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string}
+   */
+  _extractEnumName(node, content, text) {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        return this._nodeText(child, content);
+      }
+    }
+
+    const match = text.match(/\benum\s+(\w+)/);
+    return match ? match[1] : 'Unknown';
+  }
+
+  /**
+   * Extract enum members (values).
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {Array<{name: string}>}
+   */
+  _extractEnumMembers(node, content, text) {
+    const members = [];
+
+    // Try to find enum body / enum constants
+    const bodyNode = this._findChildByTypes(node, [
+      'enum_body', 'enum_constant_list', 'body', '{',
+    ]);
+
+    if (bodyNode) {
+      for (let i = 0; i < bodyNode.childCount; i++) {
+        const child = bodyNode.child(i);
+        if (this._isNodeType(child.type, [
+          'enum_constant', 'enum_value', 'identifier',
+          'type_identifier',
+        ])) {
+          const memberName = this._nodeText(child, content).trim();
+          if (memberName && memberName !== ',' && memberName !== '{' && memberName !== '}') {
+            members.push({ name: memberName });
+          }
+        }
+      }
+    }
+
+    // Fallback: regex extraction from the enum body
+    if (members.length === 0) {
+      const bodyMatch = text.match(/\{([^}]*?)(?:;|})/s);
+      if (bodyMatch) {
+        const body = bodyMatch[1];
+        // Split by commas, filter out methods/constructors
+        const parts = body.split(',');
+        for (const part of parts) {
+          const trimmed = part.trim();
+          // Enum members are simple identifiers, possibly with constructor args
+          const memberMatch = trimmed.match(/^(\w+)/);
+          if (memberMatch && memberMatch[1] !== '' && !memberMatch[1].match(/^(final|const|static|void|int|String|bool|double|class)/)) {
+            members.push({ name: memberMatch[1] });
+          }
+        }
+      }
+    }
+
+    return members;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Top-level function extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from a top-level function node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object|null}
+   */
+  _extractFunction(node, content, scope) {
+    const text = this._nodeText(node, content);
+
+    // Skip if this looks like a class/mixin/enum — some grammars wrap them
+    if (/^\s*(abstract\s+)?class\s/.test(text)) return null;
+    if (/^\s*mixin\s/.test(text)) return null;
+    if (/^\s*enum\s/.test(text)) return null;
+
+    const name = this._extractFunctionName(node, content, text);
+    if (!name) return null;
+
+    const returnType = this._extractReturnType(node, content, text);
+    const params = this._extractParameters(node, content, text);
+    const isAsync = this._isAsyncFunction(node, content, text);
+    const isGenerator = this._isGeneratorFunction(text);
+    const typeParams = this._extractTypeParameters(node, content, text);
+
+    const references = [];
+    if (returnType) {
+      this._extractTypeReferences(returnType, references);
+    }
+    for (const p of params) {
+      if (p.type) this._extractTypeReferences(p.type, references);
+    }
+
+    return {
+      type: 'function',
+      name,
+      exported: !name.startsWith('_'),
+      returnType: returnType || null,
+      async: isAsync,
+      generator: isGenerator,
+      params,
+      typeParameters: typeParams.length > 0 ? typeParams : undefined,
+      scope,
+      references: [...new Set(references)],
+      imports: [],
+    };
+  }
+
+  /**
+   * Extract function name from node or text.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string|null}
+   */
+  _extractFunctionName(node, content, text) {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+
+    // Look for identifier children
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'identifier') {
+        const val = this._nodeText(child, content);
+        // Skip keywords that might appear as identifiers
+        if (!['void', 'async', 'static', 'final', 'const', 'var', 'late', 'get', 'set'].includes(val)) {
+          return val;
+        }
+      }
+    }
+
+    // Fallback: regex
+    const match = text.match(/(?:(?:Future|Stream|void|int|String|bool|double|[\w<>?,\s]+)\s+)?(\w+)\s*[<(]/);
+    if (match) return match[1];
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Typedef extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract metadata from a typedef node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractTypedef(node, content, scope) {
+    const text = this._nodeText(node, content);
+
+    const match = text.match(/typedef\s+(\w+)/);
+    const name = match ? match[1] : 'Unknown';
+
+    return {
+      type: 'typedef',
+      name,
+      exported: !name.startsWith('_'),
+      definition: text.trim(),
+      scope,
+      references: [],
+      imports: [],
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Class body extraction (methods, constructors, fields)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract members from a class/mixin/extension/enum body.
+   * @param {object} node - the class/mixin/extension node
+   * @param {string} content
+   * @param {string} className - name of the containing class
+   * @param {Array} defines - mutated in place
+   * @param {Array} references - mutated in place
+   */
+  _extractClassBody(node, content, className, defines, references) {
+    const bodyNode = this._findClassBody(node);
+    if (!bodyNode) {
+      // Try extracting from the node itself (some grammars inline the body)
+      this._extractMembersFromNode(node, content, className, defines, references);
+      return;
+    }
+
+    this._extractMembersFromNode(bodyNode, content, className, defines, references);
+  }
+
+  /**
+   * Find the class body node from a class definition.
+   * @param {object} node
+   * @returns {object|null}
+   */
+  _findClassBody(node) {
+    const bodyNode = node.childForFieldName('body');
+    if (bodyNode) return bodyNode;
+
+    // Try finding by type
+    return this._findChildByTypes(node, [
+      'class_body', 'declaration_list', 'block', 'enum_body',
+    ]);
+  }
+
+  /**
+   * Extract all members from a body node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} className
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractMembersFromNode(node, content, className, defines, references) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      try {
+        this._extractMember(child, content, className, defines, references);
+      } catch (err) {
+        // Defensive: skip problematic nodes
+        continue;
+      }
+    }
+  }
+
+  /**
+   * Extract a single member (method, constructor, field, getter, setter).
+   * @param {object} node
+   * @param {string} content
+   * @param {string} className
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractMember(node, content, className, defines, references) {
+    const type = node.type;
+    const text = this._nodeText(node, content);
+
+    // Constructor
+    if (this._isNodeType(type, ['constructor_signature', 'constructor_definition', 'constructor_declaration'])) {
+      this._extractConstructorDef(node, content, className, text, defines);
+      return;
+    }
+
+    // Method
+    if (this._isNodeType(type, [
+      'method_signature', 'method_definition', 'method_declaration',
+      'function_signature', 'function_definition',
+    ])) {
+      this._extractMethodDef(node, content, className, text, defines, references);
+      return;
+    }
+
+    // Getter
+    if (this._isNodeType(type, ['getter_signature', 'getter_definition', 'getter_declaration'])) {
+      this._extractGetterDef(node, content, text, defines, references);
+      return;
+    }
+
+    // Setter
+    if (this._isNodeType(type, ['setter_signature', 'setter_definition', 'setter_declaration'])) {
+      this._extractSetterDef(node, content, text, defines, references);
+      return;
+    }
+
+    // Field / variable declaration
+    if (this._isNodeType(type, [
+      'declaration', 'variable_declaration', 'field_declaration',
+      'final_builtin', 'initialized_variable_definition',
+      'static_final_declaration', 'static_final_declaration_list',
+    ])) {
+      this._extractFieldDef(node, content, text, defines, references);
+      return;
+    }
+
+    // Annotation (track but don't add to defines)
+    if (this._isNodeType(type, ['annotation', 'marker_annotation'])) {
+      const annotText = text.trim();
+      if (annotText.startsWith('@')) {
+        const annName = annotText.replace(/^@/, '').split('(')[0];
+        references.push(annName);
+      }
+      return;
+    }
+
+    // For declaration wrappers, recurse into children
+    if (this._isNodeType(type, ['class_member_definition', 'declaration_statement'])) {
+      for (let i = 0; i < node.childCount; i++) {
+        this._extractMember(node.child(i), content, className, defines, references);
+      }
+      return;
+    }
+
+    // Fallback: try text-based detection for constructor/method patterns
+    if (text.trim().length > 0 && !text.startsWith('//') && !text.startsWith('/*')) {
+      this._textBasedMemberExtraction(text, className, defines, references);
+    }
+  }
+
+  /**
+   * Extract a constructor definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} className
+   * @param {string} text
+   * @param {Array} defines
+   */
+  _extractConstructorDef(node, content, className, text, defines) {
+    const isFactory = text.includes('factory');
+    const isConst = /\bconst\b/.test(text);
+    let name = className;
+    let isNamed = false;
+
+    // Check for named constructor: ClassName.name(...)
+    const namedMatch = text.match(new RegExp(`${this._escapeRegex(className)}\\.([\\w]+)`));
+    if (namedMatch) {
+      name = `${className}.${namedMatch[1]}`;
+      isNamed = true;
+    }
+
+    defines.push({
+      name,
+      type: 'constructor',
+      named: isNamed,
+      const: isConst,
+      factory: isFactory,
+    });
+  }
+
+  /**
+   * Extract a method definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} className
+   * @param {string} text
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractMethodDef(node, content, className, text, defines, references) {
+    const name = this._extractFunctionName(node, content, text);
+    if (!name) return;
+
+    // Skip if this looks like a constructor
+    if (name === className || text.match(new RegExp(`^\\s*(?:factory\\s+|const\\s+)?${this._escapeRegex(className)}[.(]`))) {
+      this._extractConstructorDef(node, content, className, text, defines);
+      return;
+    }
+
+    const isStatic = /\bstatic\b/.test(text);
+    const isAbstract = text.trimEnd().endsWith(';') && !text.includes('=>') && !text.includes('{');
+    const isAsync = this._isAsyncFunction(node, content, text);
+    const returnType = this._extractReturnType(node, content, text);
+    const visibility = name.startsWith('_') ? 'private' : 'public';
+
+    if (returnType) {
+      this._extractTypeReferences(returnType, references);
+    }
+
+    defines.push({
+      name,
+      type: 'method',
+      visibility,
+      static: isStatic,
+      abstract: isAbstract,
+      async: isAsync,
+      returnType: returnType || null,
+    });
+  }
+
+  /**
+   * Extract a getter definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractGetterDef(node, content, text, defines, references) {
+    const match = text.match(/(?:(\w[\w<>?]*)\s+)?get\s+(\w+)/);
+    if (!match) return;
+
+    const returnType = match[1] || null;
+    const name = match[2];
+    const visibility = name.startsWith('_') ? 'private' : 'public';
+
+    defines.push({
+      name,
+      type: 'getter',
+      visibility,
+      returnType,
+    });
+
+    if (returnType) this._extractTypeReferences(returnType, references);
+  }
+
+  /**
+   * Extract a setter definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractSetterDef(node, content, text, defines, references) {
+    const match = text.match(/set\s+(\w+)/);
+    if (!match) return;
+
+    const name = match[1];
+    const visibility = name.startsWith('_') ? 'private' : 'public';
+
+    defines.push({
+      name,
+      type: 'setter',
+      visibility,
+    });
+  }
+
+  /**
+   * Extract a field/variable definition.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _extractFieldDef(node, content, text, defines, references) {
+    const trimmed = text.trim();
+
+    // Skip method/constructor signatures that might be wrapped in declaration nodes
+    if (trimmed.includes('(') && !trimmed.includes('=')) return;
+
+    const isFinal = /\bfinal\b/.test(trimmed);
+    const isLate = /\blate\b/.test(trimmed);
+    const isConst = /\bconst\b/.test(trimmed);
+    const isStatic = /\bstatic\b/.test(trimmed);
+
+    // Parse field: [static] [late] [final|const|var] [Type] name [= value];
+    // Remove modifiers to find type and name
+    let cleaned = trimmed
+      .replace(/\bstatic\b/, '')
+      .replace(/\blate\b/, '')
+      .replace(/\bfinal\b/, '')
+      .replace(/\bconst\b/, '')
+      .replace(/\bvar\b/, '')
+      .replace(/;$/, '')
+      .trim();
+
+    // Remove default value
+    const eqIdx = cleaned.indexOf('=');
+    if (eqIdx > 0) {
+      cleaned = cleaned.substring(0, eqIdx).trim();
+    }
+
+    // Split into type and name
+    let fieldType = null;
+    let fieldName = null;
+
+    // Check for Type<Generic> name pattern
+    const typeNameMatch = cleaned.match(/^([\w<>,?\s]+?)\s+(\w+)$/);
+    if (typeNameMatch) {
+      fieldType = typeNameMatch[1].trim();
+      fieldName = typeNameMatch[2];
+    } else {
+      // Just a name (var x / final x)
+      const nameMatch = cleaned.match(/(\w+)$/);
+      if (nameMatch) {
+        fieldName = nameMatch[1];
+      }
+    }
+
+    if (!fieldName) return;
+
+    // Skip if the name looks like a keyword
+    if (['void', 'return', 'if', 'else', 'for', 'while', 'class', 'enum'].includes(fieldName)) return;
+
+    const visibility = fieldName.startsWith('_') ? 'private' : 'public';
+
+    defines.push({
+      name: fieldName,
+      type: 'field',
+      fieldType: fieldType || null,
+      visibility,
+      final: isFinal,
+      late: isLate,
+      const: isConst,
+      static: isStatic,
+    });
+
+    if (fieldType) {
+      this._extractTypeReferences(fieldType, references);
+    }
+  }
+
+  /**
+   * Fallback: text-based member extraction when AST node types don't match.
+   * @param {string} text
+   * @param {string} className
+   * @param {Array} defines
+   * @param {Array} references
+   */
+  _textBasedMemberExtraction(text, className, defines, references) {
+    const trimmed = text.trim();
+
+    // Skip punctuation, braces, annotations
+    if (/^[{};,()@]/.test(trimmed)) return;
+    if (trimmed.startsWith('@')) return;
+
+    // Check for constructor pattern: ClassName(...) or ClassName.name(...)
+    const ctorPattern = new RegExp(`^\\s*(?:(?:factory|const)\\s+)?${this._escapeRegex(className)}(?:\\.(\\w+))?\\s*\\(`);
+    const ctorMatch = trimmed.match(ctorPattern);
+    if (ctorMatch) {
+      const namedPart = ctorMatch[1];
+      defines.push({
+        name: namedPart ? `${className}.${namedPart}` : className,
+        type: 'constructor',
+        named: !!namedPart,
+        const: /\bconst\b/.test(trimmed),
+        factory: /\bfactory\b/.test(trimmed),
+      });
+      return;
+    }
+
+    // Check for method pattern: [ReturnType] name(...)
+    const methodMatch = trimmed.match(/^(?:static\s+)?(?:(?:Future|Stream|void|int|String|bool|double|[\w<>?,\s]+?)\s+)?(\w+)\s*\(/);
+    if (methodMatch && methodMatch[1] !== className) {
+      const name = methodMatch[1];
+      if (!['if', 'for', 'while', 'switch', 'catch', 'class', 'enum', 'super', 'this'].includes(name)) {
+        const returnType = this._extractReturnTypeFromText(trimmed);
+        defines.push({
+          name,
+          type: 'method',
+          visibility: name.startsWith('_') ? 'private' : 'public',
+          static: /\bstatic\b/.test(trimmed),
+          abstract: false,
+          async: /\basync\b/.test(trimmed),
+          returnType: returnType || null,
+        });
+        return;
+      }
+    }
+
+    // Check for field pattern: [static] [late] [final|const|var] [Type] name [= ...];
+    const fieldMatch = trimmed.match(/^(?:static\s+)?(?:late\s+)?(?:final|const|var)?\s*(?:([\w<>?,\s]+?)\s+)?(\w+)\s*(?:=|;)/);
+    if (fieldMatch) {
+      const fieldType = fieldMatch[1] ? fieldMatch[1].trim() : null;
+      const fieldName = fieldMatch[2];
+      if (fieldName && !['void', 'return', 'if', 'else', 'for', 'while', 'class', 'enum'].includes(fieldName)) {
+        defines.push({
+          name: fieldName,
+          type: 'field',
+          fieldType,
+          visibility: fieldName.startsWith('_') ? 'private' : 'public',
+          final: /\bfinal\b/.test(trimmed),
+          late: /\blate\b/.test(trimmed),
+          const: /\bconst\b/.test(trimmed),
+          static: /\bstatic\b/.test(trimmed),
+        });
+        if (fieldType) this._extractTypeReferences(fieldType, references);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Import / Export extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract import statements from the root AST.
+   * @param {object} rootNode
+   * @param {string} content
+   * @returns {Array<object>}
+   */
+  _extractImports(rootNode, content) {
+    const imports = [];
+
+    // Try AST-based extraction
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const child = rootNode.child(i);
+      const text = this._nodeText(child, content).trim();
+
+      if (this._isNodeType(child.type, [
+        'import_or_export', 'import_specification', 'import_directive',
+        'library_import', 'part_directive', 'part_of_directive',
+      ]) || text.startsWith('import ')) {
+        const parsed = this._parseImportText(text);
+        if (parsed) imports.push(parsed);
+      }
+    }
+
+    // Fallback: regex-based extraction from content
+    if (imports.length === 0) {
+      const importRegex = /import\s+['"]([^'"]+)['"]\s*(as\s+(\w+))?\s*(show\s+([^;]+?))?\s*(hide\s+([^;]+?))?\s*;/g;
+      let match;
+      while ((match = importRegex.exec(content)) !== null) {
+        const from = match[1];
+        const asAlias = match[3] || null;
+        const showList = match[5] ? match[5].split(',').map(s => s.trim()).filter(Boolean) : [];
+        const hideList = match[7] ? match[7].split(',').map(s => s.trim()).filter(Boolean) : [];
+
+        const name = from.split('/').pop() || from;
+        imports.push({
+          name,
+          from,
+          show: showList,
+          hide: hideList,
+          as: asAlias,
+        });
+      }
+    }
+
+    return imports;
+  }
+
+  /**
+   * Extract export statements from the root AST.
+   * @param {object} rootNode
+   * @param {string} content
+   * @returns {Array<object>}
+   */
+  _extractExports(rootNode, content) {
+    const exports = [];
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const child = rootNode.child(i);
+      const text = this._nodeText(child, content).trim();
+
+      if (text.startsWith('export ')) {
+        const parsed = this._parseExportText(text);
+        if (parsed) exports.push(parsed);
+      }
+    }
+
+    // Fallback: regex
+    if (exports.length === 0) {
+      const exportRegex = /export\s+['"]([^'"]+)['"]\s*(show\s+([^;]+?))?\s*(hide\s+([^;]+?))?\s*;/g;
+      let match;
+      while ((match = exportRegex.exec(content)) !== null) {
+        const from = match[1];
+        const showList = match[3] ? match[3].split(',').map(s => s.trim()).filter(Boolean) : [];
+        const hideList = match[5] ? match[5].split(',').map(s => s.trim()).filter(Boolean) : [];
+
+        exports.push({
+          name: from.split('/').pop() || from,
+          from,
+          show: showList,
+          hide: hideList,
+        });
+      }
+    }
+
+    return exports;
+  }
+
+  /**
+   * Parse an import statement text into structured data.
+   * @param {string} text
+   * @returns {object|null}
+   */
+  _parseImportText(text) {
+    const match = text.match(/import\s+['"]([^'"]+)['"]\s*(as\s+(\w+))?\s*(show\s+([^;]+?))?\s*(hide\s+([^;]+?))?\s*;?/);
+    if (!match) return null;
+
+    const from = match[1];
+    const asAlias = match[3] || null;
+    const showList = match[5] ? match[5].split(',').map(s => s.trim()).filter(Boolean) : [];
+    const hideList = match[7] ? match[7].split(',').map(s => s.trim()).filter(Boolean) : [];
+
+    return {
+      name: from.split('/').pop() || from,
+      from,
+      show: showList,
+      hide: hideList,
+      as: asAlias,
+    };
+  }
+
+  /**
+   * Parse an export statement text into structured data.
+   * @param {string} text
+   * @returns {object|null}
+   */
+  _parseExportText(text) {
+    const match = text.match(/export\s+['"]([^'"]+)['"]\s*(show\s+([^;]+?))?\s*(hide\s+([^;]+?))?\s*;?/);
+    if (!match) return null;
+
+    const from = match[1];
+    const showList = match[3] ? match[3].split(',').map(s => s.trim()).filter(Boolean) : [];
+    const hideList = match[5] ? match[5].split(',').map(s => s.trim()).filter(Boolean) : [];
+
+    return {
+      name: from.split('/').pop() || from,
+      from,
+      show: showList,
+      hide: hideList,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Derive scope from file path.
+   * @param {string} filePath
+   * @returns {string[]}
+   */
+  _deriveScope(filePath) {
+    if (!filePath) return [];
+    const normalized = filePath.replace(/\\/g, '/');
+    const parts = normalized.split('/');
+
+    // Find meaningful start: lib/, src/, app/
+    const libIndex = parts.indexOf('lib');
+    const srcIndex = parts.indexOf('src');
+    const appIndex = parts.indexOf('app');
+    const startIndex = libIndex >= 0
+      ? libIndex
+      : (srcIndex >= 0 ? srcIndex : (appIndex >= 0 ? appIndex : Math.max(0, parts.length - 3)));
+
+    // Drop the filename
+    const scopeParts = parts.slice(startIndex, parts.length - 1);
+    return scopeParts.filter(p => p && p !== '.' && p !== '..');
+  }
+
+  /**
+   * Build file-level metadata when no top-level definitions are found.
+   * @param {string} filePath
+   * @param {string[]} scope
+   * @param {Array} imports
+   * @param {Array} exports
+   * @param {object} rootNode
+   * @param {string} content
+   * @returns {object}
+   */
+  _buildFileLevelMetadata(filePath, scope, imports, exports, rootNode, content) {
+    const basename = path.basename(filePath, '.dart');
+    return {
+      type: 'file',
+      name: basename,
+      scope,
+      defines: [],
+      references: [],
+      imports,
+      exports,
+    };
+  }
+
+  /**
+   * Check if a node type matches any of the given possible names.
+   * @param {string} type
+   * @param {string[]} possibleTypes
+   * @returns {boolean}
+   */
+  _isNodeType(type, possibleTypes) {
+    return possibleTypes.includes(type);
+  }
+
+  /**
+   * Find a child node matching any of the given type names.
+   * @param {object} node
+   * @param {string[]} types
+   * @returns {object|null}
+   */
+  _findChildByTypes(node, types) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (types.includes(child.type)) return child;
+    }
+    return null;
+  }
+
+  /**
+   * Extract a list of type names from a clause node (implements, with, on).
+   * @param {object} node
+   * @param {string} content
+   * @returns {string[]}
+   */
+  _extractTypeList(node, content) {
+    const types = [];
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        types.push(this._nodeText(child, content));
+      } else if (this._isNodeType(child.type, ['type_name', 'named_type', 'type'])) {
+        types.push(this._cleanTypeName(this._nodeText(child, content)));
+      }
+    }
+    // If no typed children found, try text extraction
+    if (types.length === 0) {
+      const text = this._nodeText(node, content);
+      // Remove the keyword (implements, with, on)
+      const cleaned = text.replace(/^(implements|with|on)\s+/, '');
+      if (cleaned) {
+        return cleaned.split(',').map(s => this._cleanTypeName(s.trim())).filter(Boolean);
+      }
+    }
+    return types;
+  }
+
+  /**
+   * Find a type string inside a node.
+   * @param {object} node
+   * @param {string} content
+   * @returns {string|null}
+   */
+  _findTypeInNode(node, content) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        return this._nodeText(child, content);
+      }
+      if (this._isNodeType(child.type, ['type_name', 'named_type', 'type'])) {
+        return this._nodeText(child, content);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extract type parameters (generics) from a node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _extractTypeParameters(node, content, text) {
+    // Try AST
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['type_parameters', 'type_arguments', 'type_parameter_list'])) {
+        const params = [];
+        for (let j = 0; j < child.childCount; j++) {
+          const param = child.child(j);
+          if (param.type === 'type_parameter' || param.type === 'type_identifier' || param.type === 'identifier') {
+            params.push(this._nodeText(param, content));
+          }
+        }
+        return params;
+      }
+    }
+
+    // Fallback: regex for <T, U extends Something>
+    const match = text.match(/\w+<([^()]+?)>(?:\s*(?:extends|implements|with|on|{|\())/);
+    if (match) {
+      return match[1].split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    return [];
+  }
+
+  /**
+   * Extract return type from a function/method node.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {string|null}
+   */
+  _extractReturnType(node, content, text) {
+    // Try field-based
+    const returnTypeNode = node.childForFieldName('return_type') || node.childForFieldName('returnType');
+    if (returnTypeNode) return this._nodeText(returnTypeNode, content);
+
+    // Try child node
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, ['type_identifier', 'type_name', 'named_type', 'function_type', 'void_type'])) {
+        // Make sure this isn't the function name
+        const nextSibling = node.child(i + 1);
+        if (nextSibling && (nextSibling.type === 'identifier' || nextSibling.type === 'type_identifier')) {
+          return this._nodeText(child, content);
+        }
+      }
+    }
+
+    // Fallback: text-based
+    return this._extractReturnTypeFromText(text);
+  }
+
+  /**
+   * Extract return type from raw text.
+   * @param {string} text
+   * @returns {string|null}
+   */
+  _extractReturnTypeFromText(text) {
+    const trimmed = text.trim()
+      .replace(/^static\s+/, '')
+      .replace(/^abstract\s+/, '')
+      .replace(/^@\w+\s+/, '');
+
+    // Match patterns like: Future<void> methodName(
+    // or: void methodName(
+    // or: List<Order?> methodName(
+    const match = trimmed.match(/^((?:Future|Stream|FutureOr|Iterable)<[^>]+>(?:\?)?|void|int|double|String|bool|num|dynamic|[\w]+(?:<[^>]+>)?(?:\?)?)(?:\s+(?:get\s+)?\w+\s*[(<])/);
+    if (match) return match[1];
+
+    return null;
+  }
+
+  /**
+   * Extract parameters from a function/method.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {Array<{name: string, type: string|null, required: boolean, named: boolean}>}
+   */
+  _extractParameters(node, content, text) {
+    // Try to find formal parameter list node
+    const paramListNode = this._findChildByTypes(node, [
+      'formal_parameter_list', 'parameter_list', 'parameters',
+    ]);
+
+    if (paramListNode) {
+      return this._extractParamsFromNode(paramListNode, content);
+    }
+
+    // Fallback: regex on text
+    return this._extractParamsFromText(text);
+  }
+
+  /**
+   * Extract parameters from a parameter list node.
+   * @param {object} node
+   * @param {string} content
+   * @returns {Array<object>}
+   */
+  _extractParamsFromNode(node, content) {
+    const params = [];
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (this._isNodeType(child.type, [
+        'formal_parameter', 'simple_formal_parameter', 'field_formal_parameter',
+        'default_formal_parameter', 'function_typed_formal_parameter',
+        'normal_formal_parameter', 'optional_formal_parameter',
+      ])) {
+        const paramText = this._nodeText(child, content).trim();
+        const parsed = this._parseSingleParam(paramText);
+        if (parsed) params.push(parsed);
+      }
+    }
+    return params;
+  }
+
+  /**
+   * Extract parameters from text using regex.
+   * @param {string} text
+   * @returns {Array<object>}
+   */
+  _extractParamsFromText(text) {
+    const parenMatch = text.match(/\(([^)]*)\)/);
+    if (!parenMatch) return [];
+
+    const paramsStr = parenMatch[1].trim();
+    if (!paramsStr) return [];
+
+    const params = [];
+    // Simple split (doesn't handle nested generics perfectly but good enough)
+    const parts = this._splitParams(paramsStr);
+    for (const part of parts) {
+      const parsed = this._parseSingleParam(part.trim());
+      if (parsed) params.push(parsed);
+    }
+    return params;
+  }
+
+  /**
+   * Parse a single parameter string.
+   * @param {string} text
+   * @returns {object|null}
+   */
+  _parseSingleParam(text) {
+    if (!text) return null;
+    const trimmed = text.replace(/^{/, '').replace(/}$/, '').trim();
+    if (!trimmed) return null;
+
+    const isRequired = /\brequired\b/.test(trimmed);
+    const isNamed = text.startsWith('{') || isRequired;
+    const cleaned = trimmed.replace(/\brequired\b/, '').replace(/\bthis\./, '').trim();
+
+    // Remove default value
+    const eqIdx = cleaned.indexOf('=');
+    const withoutDefault = eqIdx > 0 ? cleaned.substring(0, eqIdx).trim() : cleaned;
+
+    // Try to split into type and name
+    const typeNameMatch = withoutDefault.match(/^([\w<>,?\s]+?)\s+(\w+)$/);
+    if (typeNameMatch) {
+      return {
+        name: typeNameMatch[2],
+        type: typeNameMatch[1].trim(),
+        required: isRequired,
+        named: isNamed,
+      };
+    }
+
+    // Just a name
+    const nameMatch = withoutDefault.match(/(\w+)$/);
+    if (nameMatch) {
+      return {
+        name: nameMatch[1],
+        type: null,
+        required: isRequired,
+        named: isNamed,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Split parameter string by commas, respecting angle bracket nesting.
+   * @param {string} str
+   * @returns {string[]}
+   */
+  _splitParams(str) {
+    const parts = [];
+    let depth = 0;
+    let current = '';
+
+    for (const ch of str) {
+      if (ch === '<' || ch === '(') depth++;
+      else if (ch === '>' || ch === ')') depth--;
+      else if (ch === ',' && depth === 0) {
+        parts.push(current);
+        current = '';
+        continue;
+      }
+      current += ch;
+    }
+    if (current.trim()) parts.push(current);
+    return parts;
+  }
+
+  /**
+   * Check if a function/method is async.
+   * @param {object} node
+   * @param {string} content
+   * @param {string} text
+   * @returns {boolean}
+   */
+  _isAsyncFunction(node, content, text) {
+    // Check for async keyword in node children
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      const childText = this._nodeText(child, content);
+      if (childText === 'async' || childText === 'async*') return true;
+    }
+    // Fallback: check text
+    return /\basync\b/.test(text);
+  }
+
+  /**
+   * Check if a function is a generator (sync* or async*).
+   * @param {string} text
+   * @returns {boolean}
+   */
+  _isGeneratorFunction(text) {
+    return /\basync\s*\*/.test(text) || /\bsync\s*\*/.test(text);
+  }
+
+  /**
+   * Extract type references from a type string.
+   * @param {string} typeStr - e.g. "Future<List<Order?>>"
+   * @param {string[]} refs - mutated in place
+   */
+  _extractTypeReferences(typeStr, refs) {
+    if (!typeStr) return;
+    // Extract all identifiers from the type string
+    const identifiers = typeStr.match(/[A-Z]\w*/g);
+    if (identifiers) {
+      for (const id of identifiers) {
+        if (!['T', 'E', 'K', 'V', 'S', 'R'].includes(id)) {
+          refs.push(id);
+        }
+      }
+    }
+  }
+
+  /**
+   * Clean a type name string (remove whitespace, trailing commas).
+   * @param {string} str
+   * @returns {string}
+   */
+  _cleanTypeName(str) {
+    if (!str) return '';
+    return str.replace(/,\s*$/, '').trim();
+  }
+
+  /**
+   * Get the text content of a tree-sitter node.
+   * @param {object} node
+   * @param {string} content
+   * @returns {string}
+   */
+  _nodeText(node, content) {
+    return content.slice(node.startIndex, node.endIndex);
+  }
+
+  /**
+   * Escape a string for use in a regular expression.
+   * @param {string} str
+   * @returns {string}
+   */
+  _escapeRegex(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}
+
+module.exports = { DartAnalyzer };

--- a/analyzers/index.js
+++ b/analyzers/index.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Analyzer Registry
+ * Maps file extensions to analyzer instances.
+ * Lazy-loads analyzers and caches instances.
+ * Returns null if no analyzer is available → triggers text-based fallback.
+ */
+
+const EXTENSION_MAP = {
+  '.rb':   { analyzer: './ruby',       enrichment: './ruby/rails' },
+  '.ts':   { analyzer: './typescript', enrichment: null },
+  '.tsx':  { analyzer: './typescript', enrichment: null },
+  '.dart': { analyzer: './dart',       enrichment: './dart/flutter' },
+};
+
+/** @type {Map<string, object|null>} Cached analyzer instances keyed by analyzer path */
+const analyzerCache = new Map();
+
+/** @type {Map<string, object|null>} Cached enrichment instances keyed by enrichment path */
+const enrichmentCache = new Map();
+
+/** @type {Map<string, boolean|null>} Project-level framework detection flags */
+const frameworkDetectionCache = new Map();
+
+/**
+ * Detect if a project is a Rails project.
+ * @param {string} [projectRoot] - root directory of the project
+ * @returns {boolean}
+ */
+function detectRails(projectRoot) {
+  if (!projectRoot) return false;
+
+  const cacheKey = `rails:${projectRoot}`;
+  if (frameworkDetectionCache.has(cacheKey)) {
+    return frameworkDetectionCache.get(cacheKey);
+  }
+
+  let isRails = false;
+  try {
+    // Check for Rails indicators
+    const hasRoutesRb = fs.existsSync(path.join(projectRoot, 'config', 'routes.rb'));
+    const hasAppModels = fs.existsSync(path.join(projectRoot, 'app', 'models'));
+    const hasAppControllers = fs.existsSync(path.join(projectRoot, 'app', 'controllers'));
+
+    if (hasRoutesRb || (hasAppModels && hasAppControllers)) {
+      isRails = true;
+    } else {
+      // Check Gemfile for rails gem
+      const gemfilePath = path.join(projectRoot, 'Gemfile');
+      if (fs.existsSync(gemfilePath)) {
+        const gemfileContent = fs.readFileSync(gemfilePath, 'utf8');
+        isRails = /gem\s+['"]rails['"]/.test(gemfileContent);
+      }
+    }
+  } catch (err) {
+    // Ignore filesystem errors
+  }
+
+  frameworkDetectionCache.set(cacheKey, isRails);
+  return isRails;
+}
+
+/**
+ * Detect if a project is a Flutter project.
+ * @param {string} [projectRoot] - root directory of the project
+ * @returns {boolean}
+ */
+function detectFlutter(projectRoot) {
+  if (!projectRoot) return false;
+
+  const cacheKey = `flutter:${projectRoot}`;
+  if (frameworkDetectionCache.has(cacheKey)) {
+    return frameworkDetectionCache.get(cacheKey);
+  }
+
+  let isFlutter = false;
+  try {
+    const pubspecPath = path.join(projectRoot, 'pubspec.yaml');
+    if (fs.existsSync(pubspecPath)) {
+      const pubspecContent = fs.readFileSync(pubspecPath, 'utf8');
+      isFlutter = /flutter:/.test(pubspecContent) || /package:flutter\//.test(pubspecContent);
+    }
+    // Only detect Flutter when pubspec.yaml explicitly references Flutter.
+    // A bare `lib/` directory is too generic to be a reliable indicator.
+  } catch (err) {
+    // Ignore filesystem errors
+  }
+
+  frameworkDetectionCache.set(cacheKey, isFlutter);
+  return isFlutter;
+}
+
+/**
+ * Load an analyzer module by path.
+ * @param {string} analyzerPath - relative path to analyzer module
+ * @returns {object|null} analyzer instance or null
+ */
+function loadAnalyzer(analyzerPath) {
+  if (analyzerCache.has(analyzerPath)) {
+    return analyzerCache.get(analyzerPath);
+  }
+
+  try {
+    const AnalyzerModule = require(analyzerPath);
+    const AnalyzerClass = AnalyzerModule.default || AnalyzerModule[Object.keys(AnalyzerModule)[0]];
+    const instance = new AnalyzerClass();
+    analyzerCache.set(analyzerPath, instance);
+    return instance;
+  } catch (err) {
+    console.warn(`[analyzer] Failed to load analyzer ${analyzerPath}: ${err.message}`);
+    analyzerCache.set(analyzerPath, null);
+    return null;
+  }
+}
+
+/**
+ * Load an enrichment module by path.
+ * @param {string} enrichmentPath - relative path to enrichment module
+ * @returns {object|null} enrichment module or null
+ */
+function loadEnrichment(enrichmentPath) {
+  if (enrichmentCache.has(enrichmentPath)) {
+    return enrichmentCache.get(enrichmentPath);
+  }
+
+  try {
+    const enrichment = require(enrichmentPath);
+    enrichmentCache.set(enrichmentPath, enrichment);
+    return enrichment;
+  } catch (err) {
+    console.warn(`[analyzer] Failed to load enrichment ${enrichmentPath}: ${err.message}`);
+    enrichmentCache.set(enrichmentPath, null);
+    return null;
+  }
+}
+
+/**
+ * Get the appropriate analyzer for a file extension.
+ * @param {string} extension - File extension including dot (e.g., '.rb')
+ * @param {string} [projectRoot] - Root directory of the project being processed
+ * @returns {object|null} Analyzer instance with enrichment bound, or null for text fallback
+ */
+function getAnalyzer(extension, projectRoot) {
+  const config = EXTENSION_MAP[extension];
+  if (!config) return null;
+
+  const analyzer = loadAnalyzer(config.analyzer);
+  if (!analyzer) return null;
+
+  // Check if enrichment should be applied
+  if (config.enrichment) {
+    let shouldEnrich = false;
+
+    if (extension === '.rb') {
+      shouldEnrich = detectRails(projectRoot);
+    } else if (extension === '.dart') {
+      shouldEnrich = detectFlutter(projectRoot);
+    }
+
+    if (shouldEnrich) {
+      const enrichment = loadEnrichment(config.enrichment);
+      if (enrichment && enrichment.enrich) {
+        // Create a wrapper that applies enrichment
+        const originalEnrich = analyzer.enrich.bind(analyzer);
+        const enrichFn = enrichment.enrich;
+        return {
+          parse: analyzer.parse.bind(analyzer),
+          extractMetadata: analyzer.extractMetadata.bind(analyzer),
+          chunk: analyzer.chunk.bind(analyzer),
+          enrich: (metadata, tree, content, filePath) => {
+            const base = originalEnrich(metadata, tree, content, filePath);
+            return enrichFn(base, tree, content, filePath);
+          },
+        };
+      }
+    }
+  }
+
+  return analyzer;
+}
+
+/**
+ * Get analyzer stats for the current session.
+ * @returns {object} stats object
+ */
+function getAnalyzerStats() {
+  const analyzersUsed = [];
+  const enrichmentsApplied = [];
+
+  for (const [key, instance] of analyzerCache) {
+    if (instance) analyzersUsed.push(path.basename(key));
+  }
+  for (const [key, instance] of enrichmentCache) {
+    if (instance) enrichmentsApplied.push(path.basename(path.dirname(key)));
+  }
+
+  return { analyzersUsed, enrichmentsApplied };
+}
+
+/**
+ * Reset all caches (for testing).
+ */
+function resetRegistry() {
+  analyzerCache.clear();
+  enrichmentCache.clear();
+  frameworkDetectionCache.clear();
+}
+
+module.exports = {
+  getAnalyzer,
+  getAnalyzerStats,
+  resetRegistry,
+  EXTENSION_MAP,
+  detectRails,
+  detectFlutter,
+};

--- a/analyzers/ruby/__tests__/fixtures/sample_concern.rb
+++ b/analyzers/ruby/__tests__/fixtures/sample_concern.rb
@@ -1,0 +1,18 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :search, ->(query) { where('name LIKE ?', "%#{query}%") }
+  end
+
+  class_methods do
+    def searchable_fields
+      [:name, :description]
+    end
+  end
+
+  def matching_score(query)
+    # Calculate relevance score
+    0.0
+  end
+end

--- a/analyzers/ruby/__tests__/fixtures/sample_controller.rb
+++ b/analyzers/ruby/__tests__/fixtures/sample_controller.rb
@@ -1,0 +1,51 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_order, only: [:show, :update, :destroy]
+
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  def index
+    @orders = current_user.orders.includes(:line_items)
+    render json: @orders
+  end
+
+  def show
+    render json: @order
+  end
+
+  def create
+    @order = current_user.orders.build(order_params)
+    if @order.save
+      render json: @order, status: :created
+    else
+      render json: @order.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @order.update(order_params)
+      render json: @order
+    else
+      render json: @order.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @order.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_order
+    @order = current_user.orders.find(params[:id])
+  end
+
+  def order_params
+    params.require(:order).permit(:status, :total, :notes)
+  end
+
+  def not_found
+    render json: { error: 'Not found' }, status: :not_found
+  end
+end

--- a/analyzers/ruby/__tests__/fixtures/sample_model.rb
+++ b/analyzers/ruby/__tests__/fixtures/sample_model.rb
@@ -1,0 +1,34 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :line_items, dependent: :destroy
+  has_one :invoice, class_name: 'OrderInvoice'
+
+  validates :status, presence: true
+  validates :total, numericality: { greater_than: 0 }
+
+  scope :pending, -> { where(status: :pending) }
+  scope :recent, -> { where('created_at > ?', 1.week.ago) }
+
+  enum status: { pending: 0, confirmed: 1, shipped: 2, cancelled: 3 }
+
+  before_save :calculate_total
+  after_create :notify_warehouse
+
+  def confirm!
+    update!(status: :confirmed)
+  end
+
+  def total_with_tax(rate = 0.1)
+    total * (1 + rate)
+  end
+
+  private
+
+  def calculate_total
+    self.total = line_items.sum(&:subtotal)
+  end
+
+  def notify_warehouse
+    WarehouseNotifier.deliver(self)
+  end
+end

--- a/analyzers/ruby/__tests__/fixtures/sample_routes.rb
+++ b/analyzers/ruby/__tests__/fixtures/sample_routes.rb
@@ -1,0 +1,20 @@
+Rails.application.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      resources :orders, only: [:index, :show, :create] do
+        member do
+          post :confirm
+        end
+        collection do
+          get :pending
+        end
+      end
+
+      resources :users, only: [:show, :update]
+
+      resource :profile, only: [:show, :update]
+    end
+  end
+
+  get '/health', to: 'health#check'
+end

--- a/analyzers/ruby/__tests__/rails-enrichment.test.js
+++ b/analyzers/ruby/__tests__/rails-enrichment.test.js
@@ -1,0 +1,433 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+// Gracefully skip all tests if tree-sitter-ruby is not available
+let RubyAnalyzer;
+let enrich;
+let treeSitterAvailable = false;
+
+try {
+  require('tree-sitter');
+  require('tree-sitter-ruby');
+  treeSitterAvailable = true;
+} catch (err) {
+  console.warn('[test] tree-sitter-ruby unavailable, skipping Rails enrichment tests: ' + err.message);
+}
+
+if (treeSitterAvailable) {
+  ({ RubyAnalyzer } = require('../../ruby/index'));
+  ({ enrich } = require('../../ruby/rails'));
+}
+
+/**
+ * Helper: parse a file and extract enriched metadata.
+ */
+function parseAndEnrich(analyzer, fixtureName, virtualPath) {
+  const content = fs.readFileSync(path.join(FIXTURES_DIR, fixtureName), 'utf8');
+  const tree = analyzer.parse(virtualPath, content);
+  const metadata = analyzer.extractMetadata(tree, virtualPath, content);
+  return enrich(metadata, tree, content, virtualPath);
+}
+
+describe('Rails Enrichment', { skip: !treeSitterAvailable ? 'tree-sitter-ruby not installed' : false }, () => {
+  let analyzer;
+
+  before(() => {
+    analyzer = new RubyAnalyzer();
+  });
+
+  // ─── Model Tests ─────────────────────────────────────────────────────────
+
+  describe('Model enrichment', () => {
+    let metadata;
+
+    before(() => {
+      metadata = parseAndEnrich(analyzer, 'sample_model.rb', 'app/models/order.rb');
+    });
+
+    it('should detect model role', () => {
+      assert.equal(metadata.framework.type, 'rails');
+      assert.equal(metadata.framework.role, 'model');
+    });
+
+    describe('associations', () => {
+      it('should extract belongs_to association', () => {
+        const belongsTo = metadata.framework.associations.find(
+          a => a.type === 'belongs_to' && a.target === 'user'
+        );
+        assert.ok(belongsTo, 'should find belongs_to :user');
+      });
+
+      it('should extract has_many association with options', () => {
+        const hasMany = metadata.framework.associations.find(
+          a => a.type === 'has_many' && a.target === 'line_items'
+        );
+        assert.ok(hasMany, 'should find has_many :line_items');
+        assert.equal(hasMany.options.dependent, 'destroy');
+      });
+
+      it('should extract has_one association with options', () => {
+        const hasOne = metadata.framework.associations.find(
+          a => a.type === 'has_one' && a.target === 'invoice'
+        );
+        assert.ok(hasOne, 'should find has_one :invoice');
+        assert.equal(hasOne.options.class_name, 'OrderInvoice');
+      });
+    });
+
+    describe('validations', () => {
+      it('should extract presence validation', () => {
+        const validation = metadata.framework.validations.find(
+          v => v.fields.includes('status')
+        );
+        assert.ok(validation, 'should find validates :status');
+        assert.equal(validation.type, 'validates');
+        assert.ok(validation.options.presence);
+      });
+
+      it('should extract numericality validation', () => {
+        const validation = metadata.framework.validations.find(
+          v => v.fields.includes('total')
+        );
+        assert.ok(validation, 'should find validates :total');
+      });
+    });
+
+    describe('scopes', () => {
+      it('should extract scope names', () => {
+        const scopeNames = metadata.framework.scopes.map(s => s.name);
+        assert.ok(scopeNames.includes('pending'), 'should find :pending scope');
+        assert.ok(scopeNames.includes('recent'), 'should find :recent scope');
+      });
+
+      it('should have body for scopes', () => {
+        const pendingScope = metadata.framework.scopes.find(s => s.name === 'pending');
+        assert.ok(pendingScope, 'pending scope should exist');
+        // The body is the lambda text
+        assert.ok(typeof pendingScope.body === 'string');
+      });
+    });
+
+    describe('callbacks', () => {
+      it('should extract before_save callback', () => {
+        const cb = metadata.framework.callbacks.find(
+          c => c.type === 'before_save' && c.method === 'calculate_total'
+        );
+        assert.ok(cb, 'should find before_save :calculate_total');
+      });
+
+      it('should extract after_create callback', () => {
+        const cb = metadata.framework.callbacks.find(
+          c => c.type === 'after_create' && c.method === 'notify_warehouse'
+        );
+        assert.ok(cb, 'should find after_create :notify_warehouse');
+      });
+    });
+
+    describe('enums', () => {
+      it('should extract enum definition', () => {
+        assert.ok(metadata.framework.enums.length > 0, 'should find at least one enum');
+        const statusEnum = metadata.framework.enums.find(e => e.name === 'status');
+        assert.ok(statusEnum, 'should find status enum');
+      });
+
+      it('should extract enum values', () => {
+        const statusEnum = metadata.framework.enums.find(e => e.name === 'status');
+        assert.ok(statusEnum.values, 'should have values');
+        assert.equal(statusEnum.values.pending, '0');
+        assert.equal(statusEnum.values.confirmed, '1');
+        assert.equal(statusEnum.values.shipped, '2');
+        assert.equal(statusEnum.values.cancelled, '3');
+      });
+    });
+  });
+
+  // ─── Controller Tests ────────────────────────────────────────────────────
+
+  describe('Controller enrichment', () => {
+    let metadata;
+
+    before(() => {
+      metadata = parseAndEnrich(analyzer, 'sample_controller.rb', 'app/controllers/orders_controller.rb');
+    });
+
+    it('should detect controller role', () => {
+      assert.equal(metadata.framework.type, 'rails');
+      assert.equal(metadata.framework.role, 'controller');
+    });
+
+    describe('filters', () => {
+      it('should extract before_action filters', () => {
+        assert.ok(metadata.framework.filters.length >= 2, 'should find at least 2 filters');
+
+        const authFilter = metadata.framework.filters.find(
+          f => f.method === 'authenticate_user!'
+        );
+        assert.ok(authFilter, 'should find authenticate_user! filter');
+        assert.equal(authFilter.type, 'before_action');
+      });
+
+      it('should extract :only options on filters', () => {
+        const setOrder = metadata.framework.filters.find(
+          f => f.method === 'set_order'
+        );
+        assert.ok(setOrder, 'should find set_order filter');
+        assert.ok(Array.isArray(setOrder.only), 'should have only array');
+        assert.ok(setOrder.only.includes('show'));
+        assert.ok(setOrder.only.includes('update'));
+        assert.ok(setOrder.only.includes('destroy'));
+      });
+    });
+
+    describe('strong params', () => {
+      it('should extract params.require().permit() pattern', () => {
+        assert.ok(metadata.framework.strongParams.length > 0, 'should find strong params');
+
+        const orderParams = metadata.framework.strongParams.find(
+          sp => sp.require === 'order'
+        );
+        assert.ok(orderParams, 'should find params.require(:order)');
+        assert.ok(orderParams.permit.includes('status'));
+        assert.ok(orderParams.permit.includes('total'));
+        assert.ok(orderParams.permit.includes('notes'));
+      });
+    });
+
+    describe('rescue handlers', () => {
+      it('should extract rescue_from declarations', () => {
+        assert.ok(metadata.framework.rescueHandlers.length > 0, 'should find rescue handlers');
+
+        const handler = metadata.framework.rescueHandlers[0];
+        assert.ok(
+          handler.exception.includes('RecordNotFound') || handler.exception.includes('ActiveRecord'),
+          'should reference RecordNotFound'
+        );
+        assert.equal(handler.handler, 'not_found');
+      });
+    });
+  });
+
+  // ─── Routes Tests ────────────────────────────────────────────────────────
+
+  describe('Routes enrichment', () => {
+    let metadata;
+
+    before(() => {
+      metadata = parseAndEnrich(analyzer, 'sample_routes.rb', 'config/routes.rb');
+    });
+
+    it('should detect routes role', () => {
+      assert.equal(metadata.framework.type, 'rails');
+      assert.equal(metadata.framework.role, 'routes');
+    });
+
+    it('should expand routes into endpoints', () => {
+      assert.ok(Array.isArray(metadata.framework.endpoints));
+      assert.ok(metadata.framework.endpoints.length > 0, 'should have endpoints');
+    });
+
+    describe('namespaced resources', () => {
+      it('should handle nested namespaces', () => {
+        // api/v1/orders routes
+        const orderEndpoints = metadata.framework.endpoints.filter(
+          e => e.path.includes('/api/v1/orders')
+        );
+        assert.ok(orderEndpoints.length > 0, 'should have api/v1/orders endpoints');
+      });
+
+      it('should expand only specified actions', () => {
+        // orders has only: [:index, :show, :create]
+        const orderIndex = metadata.framework.endpoints.find(
+          e => e.action === 'orders#index'
+        );
+        assert.ok(orderIndex, 'should have orders#index');
+        assert.equal(orderIndex.method, 'GET');
+
+        const orderShow = metadata.framework.endpoints.find(
+          e => e.action === 'orders#show'
+        );
+        assert.ok(orderShow, 'should have orders#show');
+
+        const orderCreate = metadata.framework.endpoints.find(
+          e => e.action === 'orders#create'
+        );
+        assert.ok(orderCreate, 'should have orders#create');
+        assert.equal(orderCreate.method, 'POST');
+
+        // Should NOT have update or destroy since only: was specified
+        const orderUpdate = metadata.framework.endpoints.find(
+          e => e.action === 'orders#update'
+        );
+        assert.equal(orderUpdate, undefined, 'should NOT have orders#update');
+
+        const orderDestroy = metadata.framework.endpoints.find(
+          e => e.action === 'orders#destroy'
+        );
+        assert.equal(orderDestroy, undefined, 'should NOT have orders#destroy');
+      });
+    });
+
+    describe('member routes', () => {
+      it('should expand member routes with :id prefix', () => {
+        const confirmEndpoint = metadata.framework.endpoints.find(
+          e => e.action === 'orders#confirm'
+        );
+        assert.ok(confirmEndpoint, 'should have member confirm route');
+        assert.equal(confirmEndpoint.method, 'POST');
+        assert.ok(confirmEndpoint.path.includes(':id'), 'member route should include :id');
+      });
+    });
+
+    describe('collection routes', () => {
+      it('should expand collection routes without :id', () => {
+        const pendingEndpoint = metadata.framework.endpoints.find(
+          e => e.action === 'orders#pending'
+        );
+        assert.ok(pendingEndpoint, 'should have collection pending route');
+        assert.equal(pendingEndpoint.method, 'GET');
+        // Collection routes should not have :id in the path before the action
+        assert.ok(!pendingEndpoint.path.includes(':id'), 'collection route should NOT include :id');
+      });
+    });
+
+    describe('singular resource', () => {
+      it('should expand singular resource routes', () => {
+        const profileShow = metadata.framework.endpoints.find(
+          e => e.action === 'profiles#show'
+        );
+        assert.ok(profileShow, 'should have profiles#show');
+        assert.equal(profileShow.method, 'GET');
+        assert.ok(profileShow.path.includes('/profile'), 'should use singular path');
+        // Singular resource should NOT have :id
+        assert.ok(!profileShow.path.includes(':id'), 'singular resource should not have :id');
+      });
+    });
+
+    describe('explicit HTTP verb routes', () => {
+      it('should handle standalone get route', () => {
+        const healthEndpoint = metadata.framework.endpoints.find(
+          e => e.path.includes('/health')
+        );
+        assert.ok(healthEndpoint, 'should have /health endpoint');
+        assert.equal(healthEndpoint.method, 'GET');
+        assert.equal(healthEndpoint.action, 'health#check');
+      });
+    });
+
+    describe('users resource', () => {
+      it('should expand users with only show and update', () => {
+        const userShow = metadata.framework.endpoints.find(
+          e => e.action === 'users#show'
+        );
+        assert.ok(userShow, 'should have users#show');
+
+        const userUpdate = metadata.framework.endpoints.find(
+          e => e.action === 'users#update'
+        );
+        assert.ok(userUpdate, 'should have users#update');
+
+        const userIndex = metadata.framework.endpoints.find(
+          e => e.action === 'users#index'
+        );
+        assert.equal(userIndex, undefined, 'should NOT have users#index');
+      });
+    });
+  });
+
+  // ─── Concern Tests ───────────────────────────────────────────────────────
+
+  describe('Concern enrichment', () => {
+    let metadata;
+
+    before(() => {
+      metadata = parseAndEnrich(
+        analyzer, 'sample_concern.rb', 'app/models/concerns/searchable.rb'
+      );
+    });
+
+    it('should detect concern role', () => {
+      assert.equal(metadata.framework.type, 'rails');
+      assert.equal(metadata.framework.role, 'concern');
+    });
+
+    it('should detect ActiveSupport::Concern', () => {
+      assert.ok(
+        metadata.framework.concern.isActiveSupportConcern,
+        'should detect extend ActiveSupport::Concern'
+      );
+    });
+
+    it('should detect included block', () => {
+      assert.ok(
+        metadata.framework.concern.hasIncludedBlock,
+        'should detect included do...end block'
+      );
+    });
+
+    it('should detect class_methods block', () => {
+      assert.ok(
+        metadata.framework.concern.hasClassMethods,
+        'should detect class_methods do...end block'
+      );
+    });
+  });
+
+  // ─── Edge Cases ──────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    it('should handle file with no Rails patterns gracefully', () => {
+      const code = `
+class PlainRuby
+  def hello
+    puts "Hello"
+  end
+end`;
+      const tree = analyzer.parse('lib/plain_ruby.rb', code);
+      const baseMetadata = analyzer.extractMetadata(tree, 'lib/plain_ruby.rb', code);
+      const enriched = enrich(baseMetadata, tree, code, 'lib/plain_ruby.rb');
+
+      assert.equal(enriched.framework.type, 'rails');
+      // Should not crash, framework key should exist but no role-specific data
+      assert.equal(enriched.framework.role, undefined);
+    });
+
+    it('should handle model with no associations', () => {
+      const code = `
+class EmptyModel < ApplicationRecord
+end`;
+      const tree = analyzer.parse('app/models/empty_model.rb', code);
+      const baseMetadata = analyzer.extractMetadata(tree, 'app/models/empty_model.rb', code);
+      const enriched = enrich(baseMetadata, tree, code, 'app/models/empty_model.rb');
+
+      assert.equal(enriched.framework.role, 'model');
+      assert.deepEqual(enriched.framework.associations, []);
+      assert.deepEqual(enriched.framework.validations, []);
+      assert.deepEqual(enriched.framework.scopes, []);
+      assert.deepEqual(enriched.framework.callbacks, []);
+      assert.deepEqual(enriched.framework.enums, []);
+    });
+
+    it('should handle controller with no filters', () => {
+      const code = `
+class SimpleController < ApplicationController
+  def index
+    render json: []
+  end
+end`;
+      const tree = analyzer.parse('app/controllers/simple_controller.rb', code);
+      const baseMetadata = analyzer.extractMetadata(tree, 'app/controllers/simple_controller.rb', code);
+      const enriched = enrich(baseMetadata, tree, code, 'app/controllers/simple_controller.rb');
+
+      assert.equal(enriched.framework.role, 'controller');
+      assert.deepEqual(enriched.framework.filters, []);
+      assert.deepEqual(enriched.framework.strongParams, []);
+      assert.deepEqual(enriched.framework.rescueHandlers, []);
+    });
+  });
+});

--- a/analyzers/ruby/__tests__/ruby-analyzer.test.js
+++ b/analyzers/ruby/__tests__/ruby-analyzer.test.js
@@ -1,0 +1,284 @@
+'use strict';
+
+const { describe, it, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+// Gracefully skip all tests if tree-sitter-ruby is not available
+let RubyAnalyzer;
+let treeSitterAvailable = false;
+
+try {
+  require('tree-sitter');
+  require('tree-sitter-ruby');
+  treeSitterAvailable = true;
+} catch (err) {
+  console.warn('[test] tree-sitter-ruby unavailable, skipping Ruby analyzer tests: ' + err.message);
+}
+
+if (treeSitterAvailable) {
+  ({ RubyAnalyzer } = require('../../ruby/index'));
+}
+
+describe('RubyAnalyzer', { skip: !treeSitterAvailable ? 'tree-sitter-ruby not installed' : false }, () => {
+  let analyzer;
+  let modelContent;
+  let controllerContent;
+  let concernContent;
+
+  before(() => {
+    analyzer = new RubyAnalyzer();
+    modelContent = fs.readFileSync(path.join(FIXTURES_DIR, 'sample_model.rb'), 'utf8');
+    controllerContent = fs.readFileSync(path.join(FIXTURES_DIR, 'sample_controller.rb'), 'utf8');
+    concernContent = fs.readFileSync(path.join(FIXTURES_DIR, 'sample_concern.rb'), 'utf8');
+  });
+
+  describe('parse()', () => {
+    it('should parse a Ruby file and return a tree', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      assert.ok(tree, 'tree should not be null');
+      assert.ok(tree.rootNode, 'tree should have a rootNode');
+    });
+
+    it('should return null when tree-sitter-ruby is unavailable', () => {
+      // We simulate this by testing the loadParser behavior;
+      // since tree-sitter IS available in this context, we verify the parse succeeds
+      const tree = analyzer.parse('test.rb', 'class Foo; end');
+      assert.ok(tree !== null);
+    });
+
+    it('should handle empty content', () => {
+      const tree = analyzer.parse('empty.rb', '');
+      assert.ok(tree, 'tree should still be returned for empty content');
+    });
+
+    it('should handle syntax errors gracefully', () => {
+      const tree = analyzer.parse('broken.rb', 'class Foo < ; end');
+      // tree-sitter is error-tolerant and still returns a tree
+      assert.ok(tree, 'tree should still be returned for broken syntax');
+    });
+  });
+
+  describe('extractMetadata() - class extraction', () => {
+    it('should extract class name and inheritance', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      assert.equal(metadata.type, 'class');
+      assert.equal(metadata.name, 'Order');
+      assert.equal(metadata.inherits, 'ApplicationRecord');
+    });
+
+    it('should include the class itself in defines', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      const classDef = metadata.defines.find(d => d.name === 'Order' && d.type === 'class');
+      assert.ok(classDef, 'should have a class definition for Order');
+    });
+
+    it('should extract public methods', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      const confirmMethod = metadata.defines.find(d => d.name === 'confirm!');
+      assert.ok(confirmMethod, 'should find confirm! method');
+      assert.equal(confirmMethod.type, 'method');
+      assert.equal(confirmMethod.visibility, 'public');
+
+      const taxMethod = metadata.defines.find(d => d.name === 'total_with_tax');
+      assert.ok(taxMethod, 'should find total_with_tax method');
+      assert.equal(taxMethod.visibility, 'public');
+    });
+
+    it('should extract scope from file path', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      assert.ok(Array.isArray(metadata.scope));
+      assert.ok(metadata.scope.includes('app'));
+      assert.ok(metadata.scope.includes('models'));
+    });
+
+    it('should collect references to other classes', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      assert.ok(metadata.references.includes('ApplicationRecord'),
+        'should reference ApplicationRecord');
+    });
+  });
+
+  describe('extractMetadata() - visibility modifiers', () => {
+    it('should track visibility state for private methods', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/order.rb', modelContent);
+
+      const calculateTotal = metadata.defines.find(d => d.name === 'calculate_total');
+      assert.ok(calculateTotal, 'should find calculate_total method');
+      assert.equal(calculateTotal.visibility, 'private',
+        'calculate_total should be private');
+
+      const notifyWarehouse = metadata.defines.find(d => d.name === 'notify_warehouse');
+      assert.ok(notifyWarehouse, 'should find notify_warehouse method');
+      assert.equal(notifyWarehouse.visibility, 'private',
+        'notify_warehouse should be private');
+    });
+
+    it('should handle protected visibility', () => {
+      const code = `
+class Foo
+  def public_method; end
+
+  protected
+
+  def protected_method; end
+
+  private
+
+  def private_method; end
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      const pubMethod = metadata.defines.find(d => d.name === 'public_method');
+      assert.equal(pubMethod.visibility, 'public');
+
+      const protMethod = metadata.defines.find(d => d.name === 'protected_method');
+      assert.equal(protMethod.visibility, 'protected');
+
+      const privMethod = metadata.defines.find(d => d.name === 'private_method');
+      assert.equal(privMethod.visibility, 'private');
+    });
+  });
+
+  describe('extractMetadata() - module includes/extends', () => {
+    it('should extract include statements', () => {
+      const code = `
+class MyModel < ApplicationRecord
+  include Searchable
+  include Filterable
+end`;
+      const tree = analyzer.parse('app/models/my_model.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/my_model.rb', code);
+
+      assert.ok(metadata.includes.includes('Searchable'));
+      assert.ok(metadata.includes.includes('Filterable'));
+    });
+
+    it('should extract extend statements', () => {
+      const code = `
+class MyModel < ApplicationRecord
+  extend ClassMethods
+end`;
+      const tree = analyzer.parse('app/models/my_model.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/my_model.rb', code);
+
+      assert.ok(metadata.extends.includes('ClassMethods'));
+    });
+
+    it('should add included/extended modules to references', () => {
+      const code = `
+class MyModel < ApplicationRecord
+  include Searchable
+  extend ClassMethods
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      assert.ok(metadata.references.includes('Searchable'));
+      assert.ok(metadata.references.includes('ClassMethods'));
+    });
+  });
+
+  describe('extractMetadata() - attr_reader/writer/accessor', () => {
+    it('should extract attr_reader', () => {
+      const code = `
+class Config
+  attr_reader :name, :version
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      assert.ok(metadata.attributes.find(a => a.name === 'name' && a.access === 'reader'));
+      assert.ok(metadata.attributes.find(a => a.name === 'version' && a.access === 'reader'));
+    });
+
+    it('should extract attr_writer', () => {
+      const code = `
+class Config
+  attr_writer :name
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      assert.ok(metadata.attributes.find(a => a.name === 'name' && a.access === 'writer'));
+    });
+
+    it('should extract attr_accessor', () => {
+      const code = `
+class Config
+  attr_accessor :name, :email
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      assert.ok(metadata.attributes.find(a => a.name === 'name' && a.access === 'accessor'));
+      assert.ok(metadata.attributes.find(a => a.name === 'email' && a.access === 'accessor'));
+    });
+  });
+
+  describe('extractMetadata() - constants', () => {
+    it('should extract constant assignments', () => {
+      const code = `
+class Config
+  MAX_ITEMS = 100
+  DEFAULT_NAME = 'test'
+end`;
+      const tree = analyzer.parse('test.rb', code);
+      const metadata = analyzer.extractMetadata(tree, 'test.rb', code);
+
+      const maxItems = metadata.constants.find(c => c.name === 'MAX_ITEMS');
+      assert.ok(maxItems, 'should find MAX_ITEMS constant');
+      assert.equal(maxItems.value, '100');
+    });
+  });
+
+  describe('extractMetadata() - module definitions', () => {
+    it('should extract module metadata', () => {
+      const tree = analyzer.parse('app/models/concerns/searchable.rb', concernContent);
+      const metadata = analyzer.extractMetadata(tree, 'app/models/concerns/searchable.rb', concernContent);
+
+      assert.equal(metadata.type, 'module');
+      assert.equal(metadata.name, 'Searchable');
+    });
+  });
+
+  describe('chunk()', () => {
+    it('should produce chunks from a parsed tree', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const chunks = analyzer.chunk(tree, modelContent, { maxSize: 500 }, 'app/models/order.rb');
+
+      assert.ok(Array.isArray(chunks), 'chunks should be an array');
+      assert.ok(chunks.length > 0, 'should produce at least one chunk');
+
+      for (const chunk of chunks) {
+        assert.ok(typeof chunk.content === 'string');
+        assert.ok(typeof chunk.startLine === 'number');
+        assert.ok(typeof chunk.endLine === 'number');
+        assert.ok(typeof chunk.size === 'number');
+      }
+    });
+
+    it('should respect structural boundaries', () => {
+      const tree = analyzer.parse('app/models/order.rb', modelContent);
+      const chunks = analyzer.chunk(tree, modelContent, { maxSize: 2000 }, 'app/models/order.rb');
+
+      // With a large maxSize, the whole class should fit in fewer chunks
+      assert.ok(chunks.length >= 1);
+    });
+  });
+});

--- a/analyzers/ruby/index.js
+++ b/analyzers/ruby/index.js
@@ -1,0 +1,466 @@
+'use strict';
+
+const { BaseAnalyzer } = require('../base-analyzer');
+const { loadParser } = require('../shared/tree-sitter-loader');
+
+/**
+ * Ruby language analyzer.
+ * Uses tree-sitter-ruby to parse Ruby source files and extract semantic metadata.
+ *
+ * Extracts: classes, modules, methods, visibility modifiers, module operations
+ * (include/extend/prepend), constants, and attribute accessors.
+ */
+class RubyAnalyzer extends BaseAnalyzer {
+  /**
+   * Parse Ruby source code into a tree-sitter AST.
+   * @param {string} filePath - Path to the file
+   * @param {string} content - Raw file content
+   * @returns {object|null} Parsed tree-sitter tree, or null if parsing fails
+   */
+  parse(filePath, content) {
+    const loaded = loadParser('ruby');
+    if (!loaded) return null;
+
+    try {
+      const tree = loaded.parser.parse(content);
+      return tree;
+    } catch (err) {
+      console.warn(`[ruby-analyzer] Failed to parse ${filePath}: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Extract semantic metadata from a parsed Ruby AST.
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} filePath - Path for context
+   * @param {string} content - Raw content
+   * @returns {object} Metadata object
+   */
+  extractMetadata(tree, filePath, content) {
+    const rootNode = tree.rootNode;
+    const scope = this._deriveScope(filePath);
+
+    // Find top-level classes and modules
+    const topLevelDefs = this._findTopLevelDefinitions(rootNode, content);
+
+    if (topLevelDefs.length === 0) {
+      // No classes or modules — extract file-level info
+      return this._extractFileLevelMetadata(rootNode, content, filePath, scope);
+    }
+
+    // Pick the primary definition (first or largest)
+    const primary = this._selectPrimary(topLevelDefs);
+    const node = primary.node;
+
+    const metadata = {
+      type: primary.type,
+      name: primary.name,
+      scope,
+      defines: [],
+      references: [],
+      includes: [],
+      extends: [],
+      attributes: [],
+      constants: [],
+    };
+
+    if (primary.inherits) {
+      metadata.inherits = primary.inherits;
+      metadata.references.push(primary.inherits);
+    }
+
+    // Add the class/module itself as a definition
+    metadata.defines.push({ name: primary.name, type: primary.type });
+
+    // Extract body contents
+    const bodyNode = node.childForFieldName('body');
+    if (bodyNode) {
+      this._extractBodyContents(bodyNode, content, metadata);
+    }
+
+    // Deduplicate references
+    metadata.references = [...new Set(metadata.references)];
+
+    return metadata;
+  }
+
+  /**
+   * Derive scope from file path by extracting meaningful segments.
+   * @param {string} filePath
+   * @returns {string[]}
+   */
+  _deriveScope(filePath) {
+    if (!filePath) return [];
+    const normalized = filePath.replace(/\\/g, '/');
+    const parts = normalized.split('/');
+
+    // Find meaningful path segments (e.g., app/models, lib/concerns)
+    const appIndex = parts.indexOf('app');
+    const libIndex = parts.indexOf('lib');
+    const startIndex = appIndex >= 0 ? appIndex : (libIndex >= 0 ? libIndex : Math.max(0, parts.length - 3));
+
+    // Take segments from start to the file (exclusive), drop the filename
+    const scopeParts = parts.slice(startIndex, parts.length - 1);
+
+    return scopeParts.filter(p => p && p !== '.' && p !== '..');
+  }
+
+  /**
+   * Find all top-level class and module definitions.
+   * @param {object} rootNode
+   * @param {string} content
+   * @returns {Array<{type: string, name: string, inherits: string|null, node: object, size: number}>}
+   */
+  _findTopLevelDefinitions(rootNode, content) {
+    const defs = [];
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const child = rootNode.child(i);
+
+      if (child.type === 'class') {
+        const nameNode = child.childForFieldName('name');
+        const superclassNode = child.childForFieldName('superclass');
+        const name = nameNode ? this._nodeText(nameNode, content) : 'Anonymous';
+        // tree-sitter-ruby's superclass node includes the `<` token, strip it
+        const inherits = superclassNode ? this._nodeText(superclassNode, content).replace(/^<\s*/, '') : null;
+        defs.push({
+          type: 'class',
+          name,
+          inherits,
+          node: child,
+          size: child.endIndex - child.startIndex,
+        });
+      } else if (child.type === 'module') {
+        const nameNode = child.childForFieldName('name');
+        const name = nameNode ? this._nodeText(nameNode, content) : 'Anonymous';
+        defs.push({
+          type: 'module',
+          name,
+          inherits: null,
+          node: child,
+          size: child.endIndex - child.startIndex,
+        });
+      }
+    }
+
+    return defs;
+  }
+
+  /**
+   * Select the primary definition (first one, or largest if first is trivially small).
+   * @param {Array} defs
+   * @returns {object}
+   */
+  _selectPrimary(defs) {
+    if (defs.length === 1) return defs[0];
+
+    // Return the first one — typical Ruby convention is one class/module per file
+    return defs[0];
+  }
+
+  /**
+   * Extract metadata from a class/module body node.
+   * Tracks visibility state across method definitions.
+   * @param {object} bodyNode
+   * @param {string} content
+   * @param {object} metadata - mutated in place
+   */
+  _extractBodyContents(bodyNode, content, metadata) {
+    let currentVisibility = 'public';
+
+    for (let i = 0; i < bodyNode.childCount; i++) {
+      const child = bodyNode.child(i);
+
+      switch (child.type) {
+        case 'method': {
+          const methodName = this._getMethodName(child, content);
+          if (methodName) {
+            metadata.defines.push({
+              name: methodName,
+              type: 'method',
+              visibility: currentVisibility,
+            });
+          }
+          // Collect references from method body
+          this._collectReferences(child, content, metadata.references);
+          break;
+        }
+
+        case 'singleton_method': {
+          const methodName = this._getMethodName(child, content);
+          if (methodName) {
+            metadata.defines.push({
+              name: `self.${methodName}`,
+              type: 'method',
+              visibility: currentVisibility,
+            });
+          }
+          this._collectReferences(child, content, metadata.references);
+          break;
+        }
+
+        case 'call': {
+          this._extractCallMetadata(child, content, metadata);
+          break;
+        }
+
+        case 'identifier': {
+          // Bare visibility modifier (private, public, protected on own line)
+          const text = this._nodeText(child, content);
+          if (text === 'private' || text === 'public' || text === 'protected') {
+            currentVisibility = text;
+          }
+          break;
+        }
+
+        case 'assignment': {
+          this._extractConstant(child, content, metadata);
+          break;
+        }
+
+        case 'class': {
+          // Nested class
+          const nameNode = child.childForFieldName('name');
+          if (nameNode) {
+            const name = this._nodeText(nameNode, content);
+            metadata.defines.push({ name, type: 'class' });
+            const superNode = child.childForFieldName('superclass');
+            if (superNode) {
+              metadata.references.push(this._nodeText(superNode, content));
+            }
+          }
+          break;
+        }
+
+        case 'module': {
+          // Nested module
+          const nameNode = child.childForFieldName('name');
+          if (nameNode) {
+            const name = this._nodeText(nameNode, content);
+            metadata.defines.push({ name, type: 'module' });
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+    }
+  }
+
+  /**
+   * Extract metadata from a `call` node (method invocations at class level).
+   * Handles: include, extend, prepend, attr_reader, attr_writer, attr_accessor,
+   * visibility modifiers applied to specific methods.
+   * @param {object} callNode
+   * @param {string} content
+   * @param {object} metadata
+   */
+  _extractCallMetadata(callNode, content, metadata) {
+    const methodNode = callNode.childForFieldName('method');
+    if (!methodNode) return;
+
+    const methodName = this._nodeText(methodNode, content);
+    const args = callNode.childForFieldName('arguments');
+
+    switch (methodName) {
+      case 'include': {
+        const modules = this._extractSymbolOrConstantArgs(args, content);
+        metadata.includes.push(...modules);
+        metadata.references.push(...modules);
+        break;
+      }
+
+      case 'extend': {
+        const modules = this._extractSymbolOrConstantArgs(args, content);
+        metadata.extends.push(...modules);
+        metadata.references.push(...modules);
+        break;
+      }
+
+      case 'prepend': {
+        const modules = this._extractSymbolOrConstantArgs(args, content);
+        // Store prepends in includes with a note, or as separate array
+        metadata.includes.push(...modules);
+        metadata.references.push(...modules);
+        break;
+      }
+
+      case 'attr_reader':
+      case 'attr_writer':
+      case 'attr_accessor': {
+        const accessType = methodName.replace('attr_', '');
+        const symbols = this._extractSymbolArgs(args, content);
+        for (const sym of symbols) {
+          metadata.attributes.push({ name: sym, access: accessType });
+        }
+        break;
+      }
+
+      case 'private':
+      case 'public':
+      case 'protected': {
+        // Visibility applied to specific methods: private :method_name
+        // These don't change the current visibility state—they target specific methods
+        break;
+      }
+
+      default:
+        // Collect references from other calls
+        this._collectReferences(callNode, content, metadata.references);
+        break;
+    }
+  }
+
+  /**
+   * Extract a constant assignment (e.g., MAX_ITEMS = 100).
+   * @param {object} assignmentNode
+   * @param {string} content
+   * @param {object} metadata
+   */
+  _extractConstant(assignmentNode, content, metadata) {
+    const leftNode = assignmentNode.childForFieldName('left');
+    const rightNode = assignmentNode.childForFieldName('right');
+
+    if (!leftNode || !rightNode) return;
+
+    const name = this._nodeText(leftNode, content);
+    // Constants in Ruby are uppercase identifiers
+    if (name && /^[A-Z][A-Z0-9_]*$/.test(name)) {
+      const value = this._nodeText(rightNode, content);
+      metadata.constants.push({ name, value });
+    }
+  }
+
+  /**
+   * Collect constant references (class names, module names) from a node subtree.
+   * @param {object} node
+   * @param {string} content
+   * @param {string[]} refs - mutated in place
+   */
+  _collectReferences(node, content, refs) {
+    if (node.type === 'constant' || node.type === 'scope_resolution') {
+      const text = this._nodeText(node, content);
+      // Filter out common built-in constants
+      if (text && !['true', 'false', 'nil', 'self'].includes(text)) {
+        refs.push(text);
+      }
+      return; // Don't recurse into scope_resolution children
+    }
+
+    for (let i = 0; i < node.childCount; i++) {
+      this._collectReferences(node.child(i), content, refs);
+    }
+  }
+
+  /**
+   * Extract symbol or constant arguments from an argument list.
+   * e.g., include Searchable, Filterable => ['Searchable', 'Filterable']
+   * @param {object} argsNode
+   * @param {string} content
+   * @returns {string[]}
+   */
+  _extractSymbolOrConstantArgs(argsNode, content) {
+    const results = [];
+    if (!argsNode) return results;
+
+    for (let i = 0; i < argsNode.childCount; i++) {
+      const child = argsNode.child(i);
+      if (child.type === 'constant' || child.type === 'scope_resolution') {
+        results.push(this._nodeText(child, content));
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Extract symbol arguments from an argument list.
+   * e.g., attr_reader :name, :email => ['name', 'email']
+   * @param {object} argsNode
+   * @param {string} content
+   * @returns {string[]}
+   */
+  _extractSymbolArgs(argsNode, content) {
+    const results = [];
+    if (!argsNode) return results;
+
+    for (let i = 0; i < argsNode.childCount; i++) {
+      const child = argsNode.child(i);
+      if (child.type === 'simple_symbol') {
+        const text = this._nodeText(child, content);
+        // Strip leading colon
+        results.push(text.replace(/^:/, ''));
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Get the name of a method node.
+   * @param {object} methodNode
+   * @param {string} content
+   * @returns {string|null}
+   */
+  _getMethodName(methodNode, content) {
+    const nameNode = methodNode.childForFieldName('name');
+    if (nameNode) return this._nodeText(nameNode, content);
+    return null;
+  }
+
+  /**
+   * Extract file-level metadata when no top-level class/module is found.
+   * @param {object} rootNode
+   * @param {string} content
+   * @param {string} filePath
+   * @param {string[]} scope
+   * @returns {object}
+   */
+  _extractFileLevelMetadata(rootNode, content, filePath, scope) {
+    const path = require('path');
+    const basename = path.basename(filePath, '.rb');
+
+    const metadata = {
+      type: 'file',
+      name: basename,
+      scope,
+      defines: [],
+      references: [],
+      includes: [],
+      extends: [],
+      attributes: [],
+      constants: [],
+    };
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const child = rootNode.child(i);
+
+      if (child.type === 'method') {
+        const name = this._getMethodName(child, content);
+        if (name) {
+          metadata.defines.push({ name, type: 'method', visibility: 'public' });
+        }
+        this._collectReferences(child, content, metadata.references);
+      } else if (child.type === 'assignment') {
+        this._extractConstant(child, content, metadata);
+      } else if (child.type === 'call') {
+        this._collectReferences(child, content, metadata.references);
+      }
+    }
+
+    metadata.references = [...new Set(metadata.references)];
+    return metadata;
+  }
+
+  /**
+   * Get the text of a tree-sitter node.
+   * @param {object} node
+   * @param {string} content
+   * @returns {string}
+   */
+  _nodeText(node, content) {
+    return content.slice(node.startIndex, node.endIndex);
+  }
+}
+
+module.exports = { RubyAnalyzer };

--- a/analyzers/ruby/rails.js
+++ b/analyzers/ruby/rails.js
@@ -1,0 +1,808 @@
+'use strict';
+
+/**
+ * Rails framework enrichment layer.
+ * Detects Rails-specific patterns (associations, validations, callbacks, routes, etc.)
+ * by analyzing the tree-sitter AST and file path conventions.
+ *
+ * Adds a `framework` key to the base metadata object.
+ */
+
+/**
+ * Enrich metadata with Rails-specific information.
+ * @param {object} metadata - Base metadata from RubyAnalyzer.extractMetadata()
+ * @param {object} tree - tree-sitter parse tree
+ * @param {string} content - Raw file content
+ * @param {string} filePath - File path for convention detection
+ * @returns {object} Enriched metadata with `framework` key
+ */
+function enrich(metadata, tree, content, filePath) {
+  const normalizedPath = (filePath || '').replace(/\\/g, '/');
+  const framework = { type: 'rails' };
+
+  // Check concern before model — app/models/concerns/ matches both patterns
+  if (isConcern(normalizedPath)) {
+    framework.role = 'concern';
+    framework.concern = extractConcernInfo(tree.rootNode, content);
+  } else if (isModel(normalizedPath)) {
+    framework.role = 'model';
+    framework.associations = extractAssociations(tree.rootNode, content);
+    framework.validations = extractValidations(tree.rootNode, content);
+    framework.scopes = extractScopes(tree.rootNode, content);
+    framework.callbacks = extractCallbacks(tree.rootNode, content);
+    framework.enums = extractEnums(tree.rootNode, content);
+  } else if (isController(normalizedPath)) {
+    framework.role = 'controller';
+    framework.filters = extractFilters(tree.rootNode, content);
+    framework.strongParams = extractStrongParams(tree.rootNode, content);
+    framework.rescueHandlers = extractRescueHandlers(tree.rootNode, content);
+  } else if (isRoutes(normalizedPath)) {
+    framework.role = 'routes';
+    framework.endpoints = expandRoutes(tree.rootNode, content);
+  }
+
+  metadata.framework = framework;
+  return metadata;
+}
+
+// ─── Path Detection ──────────────────────────────────────────────────────────
+
+function isModel(path) {
+  return /app\/models\//.test(path);
+}
+
+function isController(path) {
+  return /app\/controllers\//.test(path);
+}
+
+function isRoutes(path) {
+  return /config\/routes/.test(path);
+}
+
+function isConcern(path) {
+  return /concerns\//.test(path);
+}
+
+// ─── Node Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Get text of a node from source content.
+ * @param {object} node
+ * @param {string} content
+ * @returns {string}
+ */
+function nodeText(node, content) {
+  return content.slice(node.startIndex, node.endIndex);
+}
+
+/**
+ * Recursively find all nodes of a given type in the AST.
+ * @param {object} node - Starting node
+ * @param {string} type - Node type to find
+ * @param {Array} results - Accumulator
+ * @returns {Array}
+ */
+function findAllByType(node, type, results) {
+  results = results || [];
+  if (node.type === type) {
+    results.push(node);
+  }
+  for (let i = 0; i < node.childCount; i++) {
+    findAllByType(node.child(i), type, results);
+  }
+  return results;
+}
+
+/**
+ * Extract the first symbol argument from a call node's arguments.
+ * @param {object} argsNode
+ * @param {string} content
+ * @returns {string|null}
+ */
+function firstSymbolArg(argsNode, content) {
+  if (!argsNode) return null;
+  for (let i = 0; i < argsNode.childCount; i++) {
+    const child = argsNode.child(i);
+    if (child.type === 'simple_symbol') {
+      return nodeText(child, content).replace(/^:/, '');
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract all symbol arguments from a call node's arguments.
+ * @param {object} argsNode
+ * @param {string} content
+ * @returns {string[]}
+ */
+function allSymbolArgs(argsNode, content) {
+  const results = [];
+  if (!argsNode) return results;
+  for (let i = 0; i < argsNode.childCount; i++) {
+    const child = argsNode.child(i);
+    if (child.type === 'simple_symbol') {
+      results.push(nodeText(child, content).replace(/^:/, ''));
+    }
+  }
+  return results;
+}
+
+/**
+ * Extract hash options from arguments.
+ * Looks for hash or pair nodes and extracts key-value pairs.
+ * @param {object} argsNode
+ * @param {string} content
+ * @returns {object}
+ */
+function extractHashOptions(argsNode, content) {
+  const options = {};
+  if (!argsNode) return options;
+
+  const pairs = findAllByType(argsNode, 'pair', []);
+  for (const pair of pairs) {
+    const keyNode = pair.childForFieldName('key');
+    const valueNode = pair.childForFieldName('value');
+    if (keyNode && valueNode) {
+      let key = nodeText(keyNode, content).replace(/^:/, '');
+      const value = nodeText(valueNode, content).replace(/^:/, '').replace(/^['"]|['"]$/g, '');
+      options[key] = value;
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Check if a call node matches a specific method name.
+ * @param {object} callNode
+ * @param {string} content
+ * @param {string|string[]} methodNames
+ * @returns {boolean}
+ */
+function isCallTo(callNode, content, methodNames) {
+  const methodNode = callNode.childForFieldName('method');
+  if (!methodNode) return false;
+  const name = nodeText(methodNode, content);
+  if (Array.isArray(methodNames)) return methodNames.includes(name);
+  return name === methodNames;
+}
+
+/**
+ * Get the method name of a call node.
+ * @param {object} callNode
+ * @param {string} content
+ * @returns {string|null}
+ */
+function callMethodName(callNode, content) {
+  const methodNode = callNode.childForFieldName('method');
+  return methodNode ? nodeText(methodNode, content) : null;
+}
+
+// ─── Model Extraction ────────────────────────────────────────────────────────
+
+const ASSOCIATION_METHODS = ['has_many', 'has_one', 'belongs_to', 'has_and_belongs_to_many'];
+
+/**
+ * Extract ActiveRecord associations from model AST.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{type: string, target: string, options: object}>}
+ */
+function extractAssociations(rootNode, content) {
+  const associations = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, ASSOCIATION_METHODS)) {
+      const type = callMethodName(call, content);
+      const args = call.childForFieldName('arguments');
+      const target = firstSymbolArg(args, content);
+      if (target) {
+        const options = extractHashOptions(args, content);
+        associations.push({ type, target, options });
+      }
+    }
+  }
+
+  return associations;
+}
+
+const VALIDATION_METHODS = [
+  'validates', 'validates_presence_of', 'validates_uniqueness_of',
+  'validates_format_of', 'validates_length_of', 'validates_numericality_of',
+  'validates_inclusion_of', 'validates_exclusion_of', 'validates_acceptance_of',
+  'validates_confirmation_of', 'validates_associated', 'validate',
+];
+
+/**
+ * Extract ActiveRecord validations from model AST.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{type: string, fields: string[], options: object}>}
+ */
+function extractValidations(rootNode, content) {
+  const validations = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, VALIDATION_METHODS)) {
+      const type = callMethodName(call, content);
+      const args = call.childForFieldName('arguments');
+      const fields = allSymbolArgs(args, content);
+      const options = extractHashOptions(args, content);
+      validations.push({ type, fields, options });
+    }
+  }
+
+  return validations;
+}
+
+/**
+ * Extract ActiveRecord scopes from model AST.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{name: string, body: string}>}
+ */
+function extractScopes(rootNode, content) {
+  const scopes = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, 'scope')) {
+      const args = call.childForFieldName('arguments');
+      const name = firstSymbolArg(args, content);
+      if (name) {
+        // Extract the lambda body as the rest of the call text
+        const lambdas = findAllByType(call, 'lambda', []);
+        let body = '';
+        if (lambdas.length > 0) {
+          body = nodeText(lambdas[0], content);
+        }
+        scopes.push({ name, body });
+      }
+    }
+  }
+
+  return scopes;
+}
+
+const CALLBACK_METHODS = [
+  'before_save', 'after_save', 'before_create', 'after_create',
+  'before_update', 'after_update', 'before_destroy', 'after_destroy',
+  'before_validation', 'after_validation', 'after_initialize', 'after_find',
+  'after_touch', 'around_save', 'around_create', 'around_update', 'around_destroy',
+  'after_commit', 'after_rollback',
+];
+
+/**
+ * Extract ActiveRecord callbacks from model AST.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{type: string, method: string}>}
+ */
+function extractCallbacks(rootNode, content) {
+  const callbacks = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, CALLBACK_METHODS)) {
+      const type = callMethodName(call, content);
+      const args = call.childForFieldName('arguments');
+      const method = firstSymbolArg(args, content);
+      if (method) {
+        callbacks.push({ type, method });
+      }
+    }
+  }
+
+  return callbacks;
+}
+
+/**
+ * Extract ActiveRecord enums from model AST.
+ * Handles: enum status: { pending: 0, confirmed: 1 }
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{name: string, values: object}>}
+ */
+function extractEnums(rootNode, content) {
+  const enums = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, 'enum')) {
+      const args = call.childForFieldName('arguments');
+      if (!args) continue;
+
+      // enum status: { pending: 0, confirmed: 1 }
+      // This appears as a call with a hash argument where the key is a symbol
+      const pairs = findAllByType(args, 'pair', []);
+      for (const pair of pairs) {
+        const keyNode = pair.childForFieldName('key');
+        const valueNode = pair.childForFieldName('value');
+        if (keyNode && valueNode) {
+          const name = nodeText(keyNode, content).replace(/^:/, '');
+          const values = {};
+
+          // If the value is a hash, extract its pairs
+          const valuePairs = findAllByType(valueNode, 'pair', []);
+          if (valuePairs.length > 0) {
+            for (const vp of valuePairs) {
+              const vkNode = vp.childForFieldName('key');
+              const vvNode = vp.childForFieldName('value');
+              if (vkNode && vvNode) {
+                const vk = nodeText(vkNode, content).replace(/^:/, '');
+                const vv = nodeText(vvNode, content);
+                values[vk] = vv;
+              }
+            }
+          }
+
+          enums.push({ name, values });
+        }
+      }
+    }
+  }
+
+  return enums;
+}
+
+// ─── Controller Extraction ───────────────────────────────────────────────────
+
+const FILTER_METHODS = [
+  'before_action', 'after_action', 'around_action',
+  'skip_before_action', 'skip_after_action', 'skip_around_action',
+  'prepend_before_action', 'append_before_action',
+];
+
+/**
+ * Extract controller filters (before_action, etc).
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{type: string, method: string, only: string[]|null, except: string[]|null}>}
+ */
+function extractFilters(rootNode, content) {
+  const filters = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, FILTER_METHODS)) {
+      const type = callMethodName(call, content);
+      const args = call.childForFieldName('arguments');
+      const method = firstSymbolArg(args, content);
+      const options = extractHashOptions(args, content);
+
+      const filter = { type, method: method || null };
+
+      if (options.only) {
+        filter.only = parseArrayOption(options.only);
+      }
+      if (options.except) {
+        filter.except = parseArrayOption(options.except);
+      }
+
+      filters.push(filter);
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Parse an array-like option value.
+ * Input: "[:show, :update, :destroy]" => ['show', 'update', 'destroy']
+ * @param {string} value
+ * @returns {string[]}
+ */
+function parseArrayOption(value) {
+  if (!value) return [];
+  // Remove brackets and split
+  const cleaned = value.replace(/[\[\]]/g, '');
+  return cleaned.split(',')
+    .map(s => s.trim().replace(/^:/, ''))
+    .filter(Boolean);
+}
+
+/**
+ * Extract strong parameters patterns (params.require().permit()).
+ * Uses text-based matching on the content for reliability.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{require: string, permit: string[]}>}
+ */
+function extractStrongParams(rootNode, content) {
+  const results = [];
+  const pattern = /params\.require\(:(\w+)\)\.permit\(([^)]+)\)/g;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const requireName = match[1];
+    const permitFields = match[2]
+      .split(',')
+      .map(s => s.trim().replace(/^:/, ''))
+      .filter(Boolean);
+
+    results.push({ require: requireName, permit: permitFields });
+  }
+
+  return results;
+}
+
+/**
+ * Extract rescue_from declarations.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{exception: string, handler: string}>}
+ */
+function extractRescueHandlers(rootNode, content) {
+  const handlers = [];
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    if (isCallTo(call, content, 'rescue_from')) {
+      const args = call.childForFieldName('arguments');
+      if (!args) continue;
+
+      // First arg is typically a constant (exception class)
+      let exception = null;
+      for (let i = 0; i < args.childCount; i++) {
+        const child = args.child(i);
+        if (child.type === 'constant' || child.type === 'scope_resolution') {
+          exception = nodeText(child, content);
+          break;
+        }
+      }
+
+      const options = extractHashOptions(args, content);
+      const handler = options.with || null;
+
+      if (exception) {
+        handlers.push({ exception, handler });
+      }
+    }
+  }
+
+  return handlers;
+}
+
+// ─── Routes Extraction ───────────────────────────────────────────────────────
+
+/**
+ * Expand Rails routes into a full endpoint list.
+ * Handles: resources, resource, namespace, scope, member, collection, HTTP verbs.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{method: string, path: string, action: string}>}
+ */
+function expandRoutes(rootNode, content) {
+  const endpoints = [];
+  const routeCalls = findAllByType(rootNode, 'call', []);
+
+  // Process recursively with context (namespace path prefix)
+  processRouteNodes(rootNode, content, '', endpoints);
+  return endpoints;
+}
+
+/**
+ * Recursively process route nodes, maintaining namespace context.
+ * @param {object} node
+ * @param {string} content
+ * @param {string} prefix - current path prefix from namespaces
+ * @param {Array} endpoints - accumulated endpoints
+ */
+function processRouteNodes(node, content, prefix, endpoints) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+
+    if (child.type === 'call') {
+      processRouteCall(child, content, prefix, endpoints);
+    } else if (child.type === 'do_block' || child.type === 'block') {
+      // Continue into blocks
+      processRouteNodes(child, content, prefix, endpoints);
+    } else {
+      processRouteNodes(child, content, prefix, endpoints);
+    }
+  }
+}
+
+const HTTP_VERBS = ['get', 'post', 'put', 'patch', 'delete'];
+const RESOURCE_ACTIONS = {
+  index:   { method: 'GET',    suffix: '' },
+  show:    { method: 'GET',    suffix: '/:id' },
+  create:  { method: 'POST',   suffix: '' },
+  new:     { method: 'GET',    suffix: '/new' },
+  edit:    { method: 'GET',    suffix: '/:id/edit' },
+  update:  { method: 'PATCH',  suffix: '/:id' },
+  destroy: { method: 'DELETE', suffix: '/:id' },
+};
+
+const SINGULAR_RESOURCE_ACTIONS = {
+  show:    { method: 'GET',    suffix: '' },
+  create:  { method: 'POST',   suffix: '' },
+  new:     { method: 'GET',    suffix: '/new' },
+  edit:    { method: 'GET',    suffix: '/edit' },
+  update:  { method: 'PATCH',  suffix: '' },
+  destroy: { method: 'DELETE', suffix: '' },
+};
+
+/**
+ * Process a single route call node.
+ * @param {object} callNode
+ * @param {string} content
+ * @param {string} prefix
+ * @param {Array} endpoints
+ */
+function processRouteCall(callNode, content, prefix, endpoints) {
+  const methodName = callMethodName(callNode, content);
+  if (!methodName) return;
+
+  const args = callNode.childForFieldName('arguments');
+
+  if (methodName === 'namespace') {
+    const name = firstSymbolArg(args, content);
+    if (name) {
+      const newPrefix = prefix + '/' + name;
+      // Process the block
+      const block = callNode.childForFieldName('block') || findBlock(callNode);
+      if (block) {
+        processRouteNodes(block, content, newPrefix, endpoints);
+      }
+    }
+    return;
+  }
+
+  if (methodName === 'scope') {
+    // scope can have a path argument
+    const scopePath = firstStringOrSymbolArg(args, content);
+    const newPrefix = scopePath ? prefix + '/' + scopePath : prefix;
+    const block = callNode.childForFieldName('block') || findBlock(callNode);
+    if (block) {
+      processRouteNodes(block, content, newPrefix, endpoints);
+    }
+    return;
+  }
+
+  if (methodName === 'resources') {
+    const resourceName = firstSymbolArg(args, content);
+    if (!resourceName) return;
+
+    const resourcePath = prefix + '/' + resourceName;
+    const options = extractHashOptions(args, content);
+
+    // Determine which actions to generate
+    let actions = Object.keys(RESOURCE_ACTIONS);
+    if (options.only) {
+      actions = parseArrayOption(options.only);
+    } else if (options.except) {
+      const excluded = parseArrayOption(options.except);
+      actions = actions.filter(a => !excluded.includes(a));
+    }
+
+    for (const action of actions) {
+      const config = RESOURCE_ACTIONS[action];
+      if (config) {
+        endpoints.push({
+          method: config.method,
+          path: resourcePath + config.suffix,
+          action: resourceName + '#' + action,
+        });
+      }
+    }
+
+    // Process block for member/collection routes
+    const block = callNode.childForFieldName('block') || findBlock(callNode);
+    if (block) {
+      processResourceBlock(block, content, resourcePath, resourceName, endpoints);
+    }
+    return;
+  }
+
+  if (methodName === 'resource') {
+    const resourceName = firstSymbolArg(args, content);
+    if (!resourceName) return;
+
+    const resourcePath = prefix + '/' + resourceName;
+    const options = extractHashOptions(args, content);
+
+    let actions = Object.keys(SINGULAR_RESOURCE_ACTIONS);
+    if (options.only) {
+      actions = parseArrayOption(options.only);
+    } else if (options.except) {
+      const excluded = parseArrayOption(options.except);
+      actions = actions.filter(a => !excluded.includes(a));
+    }
+
+    // Pluralize the controller name for singular resources
+    const controllerName = resourceName + 's';
+
+    for (const action of actions) {
+      const config = SINGULAR_RESOURCE_ACTIONS[action];
+      if (config) {
+        endpoints.push({
+          method: config.method,
+          path: resourcePath + config.suffix,
+          action: controllerName + '#' + action,
+        });
+      }
+    }
+
+    const block = callNode.childForFieldName('block') || findBlock(callNode);
+    if (block) {
+      processResourceBlock(block, content, resourcePath, controllerName, endpoints);
+    }
+    return;
+  }
+
+  if (HTTP_VERBS.includes(methodName)) {
+    // Direct HTTP verb route: get '/health', to: 'health#check'
+    const routePath = firstStringOrSymbolArg(args, content);
+    const options = extractHashOptions(args, content);
+    const to = options.to || null;
+
+    if (routePath) {
+      const fullPath = prefix + (routePath.startsWith('/') ? routePath : '/' + routePath);
+      endpoints.push({
+        method: methodName.toUpperCase(),
+        path: fullPath,
+        action: to || methodName,
+      });
+    }
+    return;
+  }
+
+  // For member/collection at top level (unlikely but handle)
+  if (methodName === 'member' || methodName === 'collection') {
+    const block = callNode.childForFieldName('block') || findBlock(callNode);
+    if (block) {
+      processRouteNodes(block, content, prefix, endpoints);
+    }
+    return;
+  }
+
+  // For unrecognized calls (e.g., Rails.application.routes.draw),
+  // check if they have a block and recurse into it
+  const block = callNode.childForFieldName('block') || findBlock(callNode);
+  if (block) {
+    processRouteNodes(block, content, prefix, endpoints);
+  }
+}
+
+/**
+ * Process member and collection blocks within a resources block.
+ * @param {object} blockNode
+ * @param {string} content
+ * @param {string} resourcePath
+ * @param {string} resourceName
+ * @param {Array} endpoints
+ */
+function processResourceBlock(blockNode, content, resourcePath, resourceName, endpoints) {
+  const calls = findAllByType(blockNode, 'call', []);
+
+  for (const call of calls) {
+    const methodName = callMethodName(call, content);
+    if (!methodName) continue;
+
+    if (methodName === 'member') {
+      const block = call.childForFieldName('block') || findBlock(call);
+      if (block) {
+        processMemberCollectionBlock(block, content, resourcePath + '/:id', resourceName, endpoints);
+      }
+    } else if (methodName === 'collection') {
+      const block = call.childForFieldName('block') || findBlock(call);
+      if (block) {
+        processMemberCollectionBlock(block, content, resourcePath, resourceName, endpoints);
+      }
+    }
+  }
+}
+
+/**
+ * Process individual route calls within member/collection blocks.
+ * @param {object} blockNode
+ * @param {string} content
+ * @param {string} basePath
+ * @param {string} controllerName
+ * @param {Array} endpoints
+ */
+function processMemberCollectionBlock(blockNode, content, basePath, controllerName, endpoints) {
+  const calls = findAllByType(blockNode, 'call', []);
+
+  for (const call of calls) {
+    const verb = callMethodName(call, content);
+    if (!verb || !HTTP_VERBS.includes(verb)) continue;
+
+    const args = call.childForFieldName('arguments');
+    const actionName = firstSymbolArg(args, content) || firstStringOrSymbolArg(args, content);
+
+    if (actionName) {
+      endpoints.push({
+        method: verb.toUpperCase(),
+        path: basePath + '/' + actionName,
+        action: controllerName + '#' + actionName,
+      });
+    }
+  }
+}
+
+/**
+ * Find the first string or symbol argument from a call's arguments.
+ * @param {object} argsNode
+ * @param {string} content
+ * @returns {string|null}
+ */
+function firstStringOrSymbolArg(argsNode, content) {
+  if (!argsNode) return null;
+  for (let i = 0; i < argsNode.childCount; i++) {
+    const child = argsNode.child(i);
+    if (child.type === 'simple_symbol') {
+      return nodeText(child, content).replace(/^:/, '');
+    }
+    if (child.type === 'string') {
+      // Strip quotes
+      const text = nodeText(child, content);
+      return text.replace(/^['"]|['"]$/g, '');
+    }
+  }
+  return null;
+}
+
+/**
+ * Find a do_block or block child of a node.
+ * @param {object} node
+ * @returns {object|null}
+ */
+function findBlock(node) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === 'do_block' || child.type === 'block') {
+      return child;
+    }
+  }
+  return null;
+}
+
+// ─── Concerns Extraction ─────────────────────────────────────────────────────
+
+/**
+ * Extract concern-specific information.
+ * Detects `extend ActiveSupport::Concern` and `included`/`class_methods` blocks.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {object}
+ */
+function extractConcernInfo(rootNode, content) {
+  const info = {
+    isActiveSupportConcern: false,
+    hasIncludedBlock: false,
+    hasClassMethods: false,
+  };
+
+  const calls = findAllByType(rootNode, 'call', []);
+
+  for (const call of calls) {
+    const methodName = callMethodName(call, content);
+
+    if (methodName === 'extend') {
+      const args = call.childForFieldName('arguments');
+      if (args) {
+        const text = nodeText(args, content);
+        if (text.includes('ActiveSupport::Concern')) {
+          info.isActiveSupportConcern = true;
+        }
+      }
+    }
+
+    if (methodName === 'included') {
+      info.hasIncludedBlock = true;
+    }
+
+    if (methodName === 'class_methods') {
+      info.hasClassMethods = true;
+    }
+  }
+
+  return info;
+}
+
+module.exports = { enrich };

--- a/analyzers/shared/chunk-splitter.js
+++ b/analyzers/shared/chunk-splitter.js
@@ -1,0 +1,370 @@
+'use strict';
+
+/**
+ * AST-aware chunk splitting logic.
+ * Receives a tree-sitter AST and produces chunks that respect structural boundaries.
+ *
+ * Algorithm: recursive split-then-merge
+ * 1. Identify top-level nodes (classes, modules, functions, etc.)
+ * 2. If node fits within maxSize → one chunk
+ * 3. If node exceeds maxSize → recurse into children
+ * 4. If child still exceeds → text split within that node
+ * 5. Merge small adjacent nodes (< maxSize * 0.3) into one chunk
+ */
+
+/** Node types considered as top-level structural boundaries */
+const TOP_LEVEL_TYPES = new Set([
+  // Ruby
+  'class', 'module', 'method', 'singleton_method',
+  // TypeScript/JavaScript
+  'class_declaration', 'interface_declaration', 'type_alias_declaration',
+  'enum_declaration', 'function_declaration', 'export_statement',
+  'lexical_declaration', 'variable_declaration',
+  // Dart
+  'class_definition', 'mixin_declaration', 'extension_declaration',
+  'enum_declaration', 'function_signature', 'function_definition',
+  // Common
+  'comment', 'import_statement', 'import_or_export',
+]);
+
+/** Node types considered as child structural boundaries (within classes) */
+const CHILD_BOUNDARY_TYPES = new Set([
+  // Ruby
+  'method', 'singleton_method',
+  // TypeScript
+  'method_definition', 'public_field_definition', 'property_signature',
+  'method_signature',
+  // Dart
+  'method_signature', 'constructor_signature', 'declaration',
+  'getter_signature', 'setter_signature',
+]);
+
+/**
+ * Get the text content of a node from the source.
+ * @param {object} node - tree-sitter node
+ * @param {string} content - full source content
+ * @returns {string}
+ */
+function nodeText(node, content) {
+  return content.slice(node.startIndex, node.endIndex);
+}
+
+/**
+ * Count newlines before a position to get line number.
+ * @param {string} content - source content
+ * @param {number} index - character index
+ * @returns {number} 1-based line number
+ */
+function getLineNumber(content, index) {
+  let line = 1;
+  for (let i = 0; i < index && i < content.length; i++) {
+    if (content[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Create a chunk object from a content slice.
+ * @param {string} chunkContent - the chunk text
+ * @param {number} startIndex - start character index in original content
+ * @param {string} fullContent - full file content (for line number calculation)
+ * @param {object} [context] - optional context info
+ * @returns {object} chunk object
+ */
+function createChunkObject(chunkContent, startIndex, fullContent, context) {
+  const startLine = getLineNumber(fullContent, startIndex);
+  const endLine = startLine + chunkContent.split('\n').length - 1;
+  return {
+    content: chunkContent,
+    startLine,
+    endLine,
+    size: chunkContent.length,
+    ...(context ? { context } : {}),
+  };
+}
+
+/**
+ * Text-based splitting within a single node that exceeds maxSize.
+ * @param {string} text - text to split
+ * @param {number} startIndex - start index in original content
+ * @param {string} fullContent - full file content
+ * @param {number} maxSize - max chunk size
+ * @param {object} [context] - context info
+ * @returns {Array<object>} array of chunk objects
+ */
+function textSplit(text, startIndex, fullContent, maxSize, context) {
+  const chunks = [];
+  const lines = text.split('\n');
+  let currentLines = [];
+  let currentSize = 0;
+
+  for (const line of lines) {
+    const lineSize = line.length + 1; // +1 for newline
+    if (currentSize + lineSize > maxSize && currentLines.length > 0) {
+      const chunkText = currentLines.join('\n');
+      const chunkStart = startIndex + text.indexOf(chunkText);
+      chunks.push(createChunkObject(chunkText, chunkStart, fullContent, context));
+      currentLines = [];
+      currentSize = 0;
+    }
+    currentLines.push(line);
+    currentSize += lineSize;
+  }
+
+  if (currentLines.length > 0) {
+    const chunkText = currentLines.join('\n');
+    const chunkStart = startIndex + text.lastIndexOf(chunkText);
+    chunks.push(createChunkObject(chunkText, chunkStart >= startIndex ? chunkStart : startIndex, fullContent, context));
+  }
+
+  return chunks;
+}
+
+/**
+ * Get the signature line of a parent node for context.
+ * @param {object} node - tree-sitter node
+ * @param {string} content - source content
+ * @returns {string} first line of the node (the signature)
+ */
+function getNodeSignature(node, content) {
+  const text = nodeText(node, content);
+  const firstLine = text.split('\n')[0];
+  return firstLine.trim();
+}
+
+/**
+ * Build context object for a chunk.
+ * @param {object} node - the node this chunk belongs to
+ * @param {string} filePath - file path
+ * @param {string} content - source content
+ * @param {object} [parentNode] - parent node if this is a child
+ * @returns {object} context object
+ */
+function buildContext(node, filePath, content, parentNode) {
+  const ctx = { file: filePath };
+  if (parentNode) {
+    ctx.parent = getNodeSignature(parentNode, content);
+    const scope = [];
+    // Walk up to collect scope
+    let current = parentNode;
+    while (current) {
+      const name = getNodeName(current, content);
+      if (name) scope.unshift(name);
+      current = current.parent;
+    }
+    if (scope.length > 0) ctx.scope = scope;
+  }
+  return ctx;
+}
+
+/**
+ * Try to extract a name from a node.
+ * @param {object} node - tree-sitter node
+ * @param {string} content - source content
+ * @returns {string|null}
+ */
+function getNodeName(node, content) {
+  // Try named children with 'name' field
+  const nameChild = node.childForFieldName('name');
+  if (nameChild) return nodeText(nameChild, content);
+  // Try first identifier child
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === 'identifier' || child.type === 'constant' || child.type === 'type_identifier') {
+      return nodeText(child, content);
+    }
+  }
+  return null;
+}
+
+/**
+ * Split an AST into structurally-aware chunks.
+ * @param {object} tree - tree-sitter parse tree
+ * @param {string} content - raw source content
+ * @param {object} options - { maxSize: number, overlap: number }
+ * @param {string} [filePath] - file path for context
+ * @returns {Array<object>} array of chunk objects with content, startLine, endLine, size, context
+ */
+function splitAST(tree, content, options, filePath) {
+  const { maxSize = 1000 } = options;
+  const rootNode = tree.rootNode;
+
+  // Collect top-level nodes
+  const topLevelNodes = [];
+  for (let i = 0; i < rootNode.childCount; i++) {
+    const child = rootNode.child(i);
+    if (child.type !== 'program' && child.type !== 'ERROR') {
+      topLevelNodes.push(child);
+    }
+  }
+
+  // If no top-level nodes, fall back to text splitting
+  if (topLevelNodes.length === 0) {
+    return textSplit(content, 0, content, maxSize);
+  }
+
+  // Process each top-level node
+  const rawChunks = [];
+  for (const node of topLevelNodes) {
+    const nodeSize = node.endIndex - node.startIndex;
+    const text = nodeText(node, content);
+
+    if (nodeSize <= maxSize) {
+      rawChunks.push({
+        content: text,
+        startIndex: node.startIndex,
+        endIndex: node.endIndex,
+        node,
+        parentNode: null,
+      });
+    } else {
+      // Node exceeds maxSize — try to split by children
+      const childChunks = splitLargeNode(node, content, maxSize, filePath);
+      rawChunks.push(...childChunks);
+    }
+  }
+
+  // Merge small adjacent chunks
+  const mergedChunks = mergeSmallChunks(rawChunks, maxSize);
+
+  // Convert to final chunk format
+  return mergedChunks.map(rc => {
+    const ctx = rc.parentNode ? buildContext(rc.node, filePath, content, rc.parentNode) : undefined;
+    return createChunkObject(rc.content, rc.startIndex, content, ctx);
+  });
+}
+
+/**
+ * Split a large node by its children.
+ * @param {object} node - tree-sitter node
+ * @param {string} content - source content
+ * @param {number} maxSize - max chunk size
+ * @param {string} [filePath] - file path
+ * @returns {Array<object>} raw chunk objects
+ */
+function splitLargeNode(node, content, maxSize, filePath) {
+  const chunks = [];
+  const children = [];
+
+  for (let i = 0; i < node.childCount; i++) {
+    children.push(node.child(i));
+  }
+
+  // If no meaningful children, text-split
+  if (children.length === 0) {
+    const text = nodeText(node, content);
+    const textChunks = textSplit(text, node.startIndex, content, maxSize);
+    return textChunks.map(tc => ({
+      content: tc.content,
+      startIndex: node.startIndex,
+      endIndex: node.endIndex,
+      node,
+      parentNode: null,
+    }));
+  }
+
+  // Try to group children into chunks
+  let currentGroup = [];
+  let currentSize = 0;
+
+  for (const child of children) {
+    const childSize = child.endIndex - child.startIndex;
+    const childText = nodeText(child, content);
+
+    if (childSize > maxSize) {
+      // Flush current group
+      if (currentGroup.length > 0) {
+        chunks.push(flushGroup(currentGroup, node, content));
+        currentGroup = [];
+        currentSize = 0;
+      }
+      // Text-split the oversized child
+      const textChunks = textSplit(childText, child.startIndex, content, maxSize, buildContext(child, filePath, content, node));
+      for (const tc of textChunks) {
+        chunks.push({
+          content: tc.content,
+          startIndex: child.startIndex,
+          endIndex: child.endIndex,
+          node: child,
+          parentNode: node,
+        });
+      }
+    } else if (currentSize + childSize > maxSize && currentGroup.length > 0) {
+      // Flush current group and start new one
+      chunks.push(flushGroup(currentGroup, node, content));
+      currentGroup = [child];
+      currentSize = childSize;
+    } else {
+      currentGroup.push(child);
+      currentSize += childSize;
+    }
+  }
+
+  // Flush remaining
+  if (currentGroup.length > 0) {
+    chunks.push(flushGroup(currentGroup, node, content));
+  }
+
+  return chunks;
+}
+
+/**
+ * Flush a group of child nodes into a single raw chunk.
+ * @param {Array<object>} nodes - child nodes
+ * @param {object} parentNode - parent node
+ * @param {string} content - source content
+ * @returns {object} raw chunk
+ */
+function flushGroup(nodes, parentNode, content) {
+  const startIndex = nodes[0].startIndex;
+  const endIndex = nodes[nodes.length - 1].endIndex;
+  const text = content.slice(startIndex, endIndex);
+  return {
+    content: text,
+    startIndex,
+    endIndex,
+    node: nodes[0],
+    parentNode,
+  };
+}
+
+/**
+ * Merge adjacent small chunks.
+ * @param {Array<object>} chunks - raw chunks
+ * @param {number} maxSize - max chunk size
+ * @returns {Array<object>} merged chunks
+ */
+function mergeSmallChunks(chunks, maxSize) {
+  if (chunks.length <= 1) return chunks;
+
+  const threshold = maxSize * 0.3;
+  const merged = [];
+  let current = chunks[0];
+
+  for (let i = 1; i < chunks.length; i++) {
+    const next = chunks[i];
+    const combinedSize = current.content.length + next.content.length;
+
+    if (current.content.length < threshold && next.content.length < threshold && combinedSize <= maxSize) {
+      // Merge: combine content with content between them
+      const gapContent = current.endIndex < next.startIndex
+        ? '\n'
+        : '';
+      current = {
+        content: current.content + gapContent + next.content,
+        startIndex: current.startIndex,
+        endIndex: next.endIndex,
+        node: current.node,
+        parentNode: current.parentNode,
+      };
+    } else {
+      merged.push(current);
+      current = next;
+    }
+  }
+  merged.push(current);
+
+  return merged;
+}
+
+module.exports = { splitAST, textSplit, getLineNumber };

--- a/analyzers/shared/metadata-schema.js
+++ b/analyzers/shared/metadata-schema.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * Validation for enriched chunk format.
+ * Ensures metadata follows the expected schema.
+ */
+
+/**
+ * Validate a defines entry.
+ * @param {object} entry - { name, type, ... }
+ * @returns {boolean}
+ */
+function validateDefinesEntry(entry) {
+  return (
+    entry &&
+    typeof entry.name === 'string' &&
+    typeof entry.type === 'string'
+  );
+}
+
+/**
+ * Validate the ast metadata object on a chunk.
+ * @param {object} ast - the ast metadata
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateASTMetadata(ast) {
+  const errors = [];
+
+  if (!ast || typeof ast !== 'object') {
+    return { valid: false, errors: ['ast must be an object'] };
+  }
+
+  if (typeof ast.type !== 'string') {
+    errors.push('ast.type must be a string');
+  }
+
+  if (typeof ast.name !== 'string') {
+    errors.push('ast.name must be a string');
+  }
+
+  if (ast.defines && !Array.isArray(ast.defines)) {
+    errors.push('ast.defines must be an array');
+  } else if (ast.defines) {
+    for (let i = 0; i < ast.defines.length; i++) {
+      if (!validateDefinesEntry(ast.defines[i])) {
+        errors.push(`ast.defines[${i}] must have name (string) and type (string)`);
+      }
+    }
+  }
+
+  if (ast.references && !Array.isArray(ast.references)) {
+    errors.push('ast.references must be an array');
+  }
+
+  if (ast.scope && !Array.isArray(ast.scope)) {
+    errors.push('ast.scope must be an array');
+  }
+
+  if (ast.imports && !Array.isArray(ast.imports)) {
+    errors.push('ast.imports must be an array');
+  }
+
+  if (ast.framework && typeof ast.framework !== 'object') {
+    errors.push('ast.framework must be an object');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate an enriched chunk (backward compatible with plain chunks).
+ * @param {object} chunk - chunk object
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateChunk(chunk) {
+  const errors = [];
+
+  if (!chunk || typeof chunk !== 'object') {
+    return { valid: false, errors: ['chunk must be an object'] };
+  }
+
+  // Required base fields
+  if (typeof chunk.content !== 'string') {
+    errors.push('chunk.content must be a string');
+  }
+  if (typeof chunk.startLine !== 'number') {
+    errors.push('chunk.startLine must be a number');
+  }
+  if (typeof chunk.endLine !== 'number') {
+    errors.push('chunk.endLine must be a number');
+  }
+  if (typeof chunk.size !== 'number') {
+    errors.push('chunk.size must be a number');
+  }
+
+  // Optional ast field
+  if (chunk.ast !== undefined) {
+    const astResult = validateASTMetadata(chunk.ast);
+    if (!astResult.valid) {
+      errors.push(...astResult.errors);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = { validateChunk, validateASTMetadata, validateDefinesEntry };

--- a/analyzers/shared/tree-sitter-loader.js
+++ b/analyzers/shared/tree-sitter-loader.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Lazy-loads tree-sitter and language grammars.
+ * Handles native module compilation failures gracefully.
+ *
+ * - Caches loaded parsers (one per language)
+ * - Returns null if tree-sitter or a grammar fails to load
+ * - Logs a single warning per failed language (not per file)
+ * - Does NOT throw errors — callers check for null
+ */
+
+const loadedParsers = {};
+const failedLanguages = new Set();
+
+/**
+ * @param {string} language - 'ruby', 'typescript', or 'dart'
+ * @returns {{ parser: object, grammar: object }|null} Parser and grammar, or null if unavailable
+ */
+function loadParser(language) {
+  if (failedLanguages.has(language)) return null;
+  if (loadedParsers[language]) return loadedParsers[language];
+
+  try {
+    const Parser = require('tree-sitter');
+    const grammar = require(`tree-sitter-${language}`);
+
+    const parser = new Parser();
+
+    // tree-sitter-typescript exports { typescript, tsx } instead of a single grammar
+    if (language === 'typescript') {
+      parser.setLanguage(grammar.typescript);
+    } else {
+      parser.setLanguage(grammar);
+    }
+
+    loadedParsers[language] = { parser, grammar };
+    return loadedParsers[language];
+  } catch (err) {
+    console.warn(`[analyzer] tree-sitter-${language} unavailable: ${err.message}. Using text chunking for ${language} files.`);
+    failedLanguages.add(language);
+    return null;
+  }
+}
+
+/**
+ * Load TSX parser specifically (tree-sitter-typescript exports both).
+ * @returns {{ parser: object, grammar: object }|null}
+ */
+function loadTSXParser() {
+  if (failedLanguages.has('tsx')) return null;
+  if (loadedParsers['tsx']) return loadedParsers['tsx'];
+
+  try {
+    const Parser = require('tree-sitter');
+    const grammar = require('tree-sitter-typescript');
+    const parser = new Parser();
+    parser.setLanguage(grammar.tsx);
+    loadedParsers['tsx'] = { parser, grammar: grammar.tsx };
+    return loadedParsers['tsx'];
+  } catch (err) {
+    console.warn(`[analyzer] tree-sitter tsx unavailable: ${err.message}. Using text chunking for .tsx files.`);
+    failedLanguages.add('tsx');
+    return null;
+  }
+}
+
+/**
+ * Reset loaded parsers and failed languages (for testing).
+ */
+function resetLoaderState() {
+  Object.keys(loadedParsers).forEach(k => delete loadedParsers[k]);
+  failedLanguages.clear();
+}
+
+module.exports = { loadParser, loadTSXParser, resetLoaderState };

--- a/analyzers/typescript/__tests__/fixtures/sample_class.ts
+++ b/analyzers/typescript/__tests__/fixtures/sample_class.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'events';
+
+export abstract class BaseEntity {
+  readonly id: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(id: string) {
+    this.id = id;
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+  }
+
+  abstract validate(): boolean;
+
+  toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAt.toISOString(),
+    };
+  }
+}
+
+export class Order extends BaseEntity {
+  status: OrderStatus = 'pending';
+  private items: OrderItem[] = [];
+
+  constructor(id: string, public readonly userId: string) {
+    super(id);
+  }
+
+  validate(): boolean {
+    return this.items.length > 0;
+  }
+
+  addItem(item: OrderItem): void {
+    this.items.push(item);
+    this.updatedAt = new Date();
+  }
+
+  get total(): number {
+    return this.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  }
+
+  static create(userId: string): Order {
+    const id = Math.random().toString(36).slice(2);
+    return new Order(id, userId);
+  }
+}
+
+type OrderStatus = 'pending' | 'confirmed' | 'shipped';
+
+interface OrderItem {
+  name: string;
+  price: number;
+  quantity: number;
+}

--- a/analyzers/typescript/__tests__/fixtures/sample_interface.ts
+++ b/analyzers/typescript/__tests__/fixtures/sample_interface.ts
@@ -1,0 +1,15 @@
+import { Order } from '../models/order';
+
+export interface Repository<T> {
+  findOne(options: { where: Partial<T> }): Promise<T | null>;
+  find(options: { where: Partial<T> }): Promise<T[]>;
+  create(data: Partial<T>): T;
+  save(entity: T): Promise<T>;
+  delete(id: string): Promise<void>;
+}
+
+export interface OrderRepository extends Repository<Order> {
+  findByStatus(status: string): Promise<Order[]>;
+  findByUser(userId: string): Promise<Order[]>;
+  countByStatus(): Promise<Record<string, number>>;
+}

--- a/analyzers/typescript/__tests__/fixtures/sample_service.ts
+++ b/analyzers/typescript/__tests__/fixtures/sample_service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import type { CreateOrderDto } from '../dto/create-order.dto';
+import { Order } from '../models/order';
+import { OrderRepository } from '../repositories/order.repository';
+
+export interface OrderFilter {
+  status?: OrderStatus;
+  userId?: string;
+  fromDate?: Date;
+}
+
+export type OrderStatus = 'pending' | 'confirmed' | 'shipped' | 'cancelled';
+
+export enum Priority {
+  Low = 'low',
+  Medium = 'medium',
+  High = 'high',
+}
+
+@Injectable()
+export class OrderService {
+  constructor(private readonly repo: OrderRepository) {}
+
+  async create(data: CreateOrderDto): Promise<Order> {
+    const order = this.repo.create(data);
+    return this.repo.save(order);
+  }
+
+  async findById(id: string): Promise<Order | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  async findAll(filter: OrderFilter): Promise<Order[]> {
+    return this.repo.find({ where: filter });
+  }
+
+  private validate(data: CreateOrderDto): boolean {
+    return data.items.length > 0 && data.userId != null;
+  }
+
+  protected async notifyWarehouse(order: Order): Promise<void> {
+    // notification logic
+  }
+}

--- a/analyzers/typescript/__tests__/fixtures/sample_types.ts
+++ b/analyzers/typescript/__tests__/fixtures/sample_types.ts
@@ -1,0 +1,31 @@
+export type ID = string | number;
+
+export type Nullable<T> = T | null;
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
+export const DEFAULT_PAGE_SIZE = 20;
+
+export function paginate<T>(items: T[], page: number, pageSize: number = DEFAULT_PAGE_SIZE): PaginatedResult<T> {
+  const start = (page - 1) * pageSize;
+  const data = items.slice(start, start + pageSize);
+  return {
+    data,
+    total: items.length,
+    page,
+    pageSize,
+    hasMore: start + pageSize < items.length,
+  };
+}
+
+export const createId = (): string => Math.random().toString(36).slice(2);

--- a/analyzers/typescript/__tests__/ts-analyzer.test.js
+++ b/analyzers/typescript/__tests__/ts-analyzer.test.js
@@ -1,0 +1,495 @@
+'use strict';
+
+const { describe, it, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+// ─── Graceful skip if tree-sitter-typescript is unavailable ─────────────────
+
+let TypeScriptAnalyzer;
+let treeSitterAvailable = false;
+
+try {
+  require('tree-sitter');
+  require('tree-sitter-typescript');
+  treeSitterAvailable = true;
+} catch {
+  // tree-sitter or tree-sitter-typescript not installed
+}
+
+if (treeSitterAvailable) {
+  ({ TypeScriptAnalyzer } = require('../index'));
+}
+
+// ─── Helper: parse + extract metadata for a fixture file ────────────────────
+
+function analyzeFixture(analyzer, fixtureName) {
+  const filePath = path.join(FIXTURES, fixtureName);
+  const content = fs.readFileSync(filePath, 'utf8');
+  const tree = analyzer.parse(filePath, content);
+  assert.ok(tree, `Expected tree-sitter to parse ${fixtureName}`);
+  const metadata = analyzer.extractMetadata(tree, filePath, content);
+  return { tree, metadata, content };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('TypeScriptAnalyzer', { skip: !treeSitterAvailable ? 'tree-sitter-typescript not installed' : false }, () => {
+  let analyzer;
+
+  before(() => {
+    analyzer = new TypeScriptAnalyzer();
+  });
+
+  // ── Class parsing ───────────────────────────────────────────────────────
+
+  describe('class extraction', () => {
+    it('parses classes and extracts name and inheritance', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_class.ts');
+
+      // Primary type should be the first class (BaseEntity)
+      assert.equal(metadata.type, 'class');
+      assert.equal(metadata.name, 'BaseEntity');
+
+      // Find the Order class in definitions
+      const orderDef = metadata.definitions.find(d => d.name === 'Order');
+      assert.ok(orderDef, 'Should find Order class in definitions');
+      assert.equal(orderDef.type, 'class');
+      assert.equal(orderDef.inherits, 'BaseEntity');
+    });
+
+    it('extracts abstract classes and abstract methods', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_class.ts');
+
+      const baseEntity = metadata.definitions.find(d => d.name === 'BaseEntity');
+      assert.ok(baseEntity, 'Should find BaseEntity');
+      assert.equal(baseEntity.abstract, true, 'BaseEntity should be abstract');
+      assert.equal(baseEntity.typeInfo.abstract, true);
+
+      // Find the abstract validate method
+      const abstractMethod = baseEntity.defines.find(
+        d => d.name === 'validate' && d.abstract === true
+      );
+      assert.ok(abstractMethod, 'Should find abstract validate() method');
+    });
+
+    it('extracts methods with visibility modifiers', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderService = metadata.definitions.find(d => d.name === 'OrderService');
+      assert.ok(orderService, 'Should find OrderService');
+
+      // Public methods (default)
+      const createMethod = orderService.defines.find(d => d.name === 'create');
+      assert.ok(createMethod, 'Should find create method');
+      assert.equal(createMethod.visibility, 'public');
+      assert.equal(createMethod.async, true);
+
+      // Private method
+      const validateMethod = orderService.defines.find(d => d.name === 'validate');
+      assert.ok(validateMethod, 'Should find validate method');
+      assert.equal(validateMethod.visibility, 'private');
+
+      // Protected method
+      const notifyMethod = orderService.defines.find(d => d.name === 'notifyWarehouse');
+      assert.ok(notifyMethod, 'Should find notifyWarehouse method');
+      assert.equal(notifyMethod.visibility, 'protected');
+      assert.equal(notifyMethod.async, true);
+    });
+
+    it('extracts async methods with return types', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderService = metadata.definitions.find(d => d.name === 'OrderService');
+      const findById = orderService.defines.find(d => d.name === 'findById');
+      assert.ok(findById, 'Should find findById method');
+      assert.equal(findById.async, true);
+      assert.ok(findById.returnType, 'findById should have a return type');
+      assert.ok(
+        findById.returnType.includes('Promise'),
+        `Return type should include Promise, got: ${findById.returnType}`
+      );
+    });
+
+    it('extracts static methods', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_class.ts');
+
+      const order = metadata.definitions.find(d => d.name === 'Order');
+      assert.ok(order, 'Should find Order class');
+
+      const staticCreate = order.defines.find(d => d.name === 'create' && d.static === true);
+      assert.ok(staticCreate, 'Should find static create() method');
+    });
+
+    it('extracts getter methods', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_class.ts');
+
+      const order = metadata.definitions.find(d => d.name === 'Order');
+      assert.ok(order, 'Should find Order class');
+
+      const totalGetter = order.defines.find(d => d.name === 'total');
+      assert.ok(totalGetter, 'Should find total getter');
+      assert.equal(totalGetter.type, 'getter');
+    });
+  });
+
+  // ── Interface parsing ─────────────────────────────────────────────────
+
+  describe('interface extraction', () => {
+    it('extracts interfaces with properties and method signatures', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_interface.ts');
+
+      const repo = metadata.definitions.find(d => d.name === 'Repository');
+      assert.ok(repo, 'Should find Repository interface');
+      assert.equal(repo.type, 'interface');
+
+      // Should have method signatures
+      assert.ok(repo.properties.length > 0, 'Repository should have properties/methods');
+
+      const findOne = repo.properties.find(p => p.name === 'findOne');
+      assert.ok(findOne, 'Should find findOne method signature');
+      assert.equal(findOne.type, 'method');
+      assert.ok(findOne.returnType, 'findOne should have a return type');
+    });
+
+    it('extracts interface extends', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_interface.ts');
+
+      const orderRepo = metadata.definitions.find(d => d.name === 'OrderRepository');
+      assert.ok(orderRepo, 'Should find OrderRepository interface');
+      assert.equal(orderRepo.type, 'interface');
+      assert.ok(orderRepo.extends.length > 0, 'OrderRepository should extend something');
+      assert.ok(
+        orderRepo.extends.includes('Repository'),
+        `Should extend Repository, got: ${JSON.stringify(orderRepo.extends)}`
+      );
+    });
+
+    it('extracts generic type parameters on interfaces', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_interface.ts');
+
+      const repo = metadata.definitions.find(d => d.name === 'Repository');
+      assert.ok(repo, 'Should find Repository interface');
+      assert.ok(repo.generics.length > 0, 'Repository should have generics');
+      assert.ok(
+        repo.generics.includes('T'),
+        `Should have generic T, got: ${JSON.stringify(repo.generics)}`
+      );
+    });
+
+    it('extracts interface property signatures with optional markers', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderFilter = metadata.definitions.find(d => d.name === 'OrderFilter');
+      assert.ok(orderFilter, 'Should find OrderFilter interface');
+
+      // All properties should be optional
+      for (const prop of orderFilter.properties) {
+        if (prop.type === 'property') {
+          assert.equal(prop.optional, true, `${prop.name} should be optional`);
+        }
+      }
+    });
+  });
+
+  // ── Type alias parsing ────────────────────────────────────────────────
+
+  describe('type alias extraction', () => {
+    it('extracts type aliases', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderStatus = metadata.definitions.find(d => d.name === 'OrderStatus');
+      assert.ok(orderStatus, 'Should find OrderStatus type alias');
+      assert.equal(orderStatus.type, 'type_alias');
+      assert.ok(
+        orderStatus.definition.includes('pending'),
+        `Definition should include 'pending', got: ${orderStatus.definition}`
+      );
+    });
+
+    it('extracts type aliases with generics', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const nullable = metadata.definitions.find(d => d.name === 'Nullable');
+      assert.ok(nullable, 'Should find Nullable type alias');
+      assert.equal(nullable.type, 'type_alias');
+      assert.ok(nullable.generics.length > 0, 'Nullable should have generics');
+      assert.ok(
+        nullable.generics.includes('T'),
+        `Should have generic T, got: ${JSON.stringify(nullable.generics)}`
+      );
+    });
+
+    it('extracts simple union type aliases', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const idType = metadata.definitions.find(d => d.name === 'ID');
+      assert.ok(idType, 'Should find ID type alias');
+      assert.equal(idType.type, 'type_alias');
+      assert.ok(
+        idType.definition.includes('string') && idType.definition.includes('number'),
+        `ID definition should be a union of string | number, got: ${idType.definition}`
+      );
+    });
+  });
+
+  // ── Enum parsing ──────────────────────────────────────────────────────
+
+  describe('enum extraction', () => {
+    it('extracts enums with members and values', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const priority = metadata.definitions.find(d => d.name === 'Priority');
+      assert.ok(priority, 'Should find Priority enum');
+      assert.equal(priority.type, 'enum');
+      assert.ok(priority.members.length === 3, `Priority should have 3 members, got ${priority.members.length}`);
+
+      const low = priority.members.find(m => m.name === 'Low');
+      assert.ok(low, 'Should find Low member');
+      assert.equal(low.value, 'low');
+
+      const medium = priority.members.find(m => m.name === 'Medium');
+      assert.ok(medium, 'Should find Medium member');
+      assert.equal(medium.value, 'medium');
+
+      const high = priority.members.find(m => m.name === 'High');
+      assert.ok(high, 'Should find High member');
+      assert.equal(high.value, 'high');
+    });
+  });
+
+  // ── Import parsing ────────────────────────────────────────────────────
+
+  describe('import extraction', () => {
+    it('extracts regular imports', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const injectable = metadata.imports.find(i => i.name === 'Injectable');
+      assert.ok(injectable, 'Should find Injectable import');
+      assert.equal(injectable.from, '@nestjs/common');
+      assert.equal(injectable.isType, false);
+    });
+
+    it('extracts type imports with isType flag', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const createOrderDto = metadata.imports.find(i => i.name === 'CreateOrderDto');
+      assert.ok(createOrderDto, 'Should find CreateOrderDto import');
+      assert.equal(createOrderDto.from, '../dto/create-order.dto');
+      assert.equal(createOrderDto.isType, true, 'CreateOrderDto should be a type import');
+    });
+
+    it('differentiates type imports from regular imports', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const order = metadata.imports.find(i => i.name === 'Order');
+      assert.ok(order, 'Should find Order import');
+      assert.equal(order.isType, false, 'Order should be a regular import');
+
+      const createOrderDto = metadata.imports.find(i => i.name === 'CreateOrderDto');
+      assert.equal(createOrderDto.isType, true, 'CreateOrderDto should be a type import');
+    });
+  });
+
+  // ── Decorator parsing ─────────────────────────────────────────────────
+
+  describe('decorator extraction', () => {
+    it('handles decorators on classes', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderService = metadata.definitions.find(d => d.name === 'OrderService');
+      assert.ok(orderService, 'Should find OrderService');
+      assert.ok(
+        orderService.typeInfo.decorators.length > 0,
+        'OrderService should have decorators'
+      );
+      assert.ok(
+        orderService.typeInfo.decorators.some(d => d.includes('Injectable')),
+        `Should have @Injectable decorator, got: ${JSON.stringify(orderService.typeInfo.decorators)}`
+      );
+    });
+  });
+
+  // ── Generic type parameters ───────────────────────────────────────────
+
+  describe('generic type parameters', () => {
+    it('handles generic type parameters on functions', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const paginate = metadata.definitions.find(d => d.name === 'paginate');
+      assert.ok(paginate, 'Should find paginate function');
+      assert.ok(paginate.generics.length > 0, 'paginate should have generics');
+      assert.ok(
+        paginate.generics.includes('T'),
+        `Should have generic T, got: ${JSON.stringify(paginate.generics)}`
+      );
+    });
+
+    it('handles generic type parameters on type aliases', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const deepPartial = metadata.definitions.find(d => d.name === 'DeepPartial');
+      assert.ok(deepPartial, 'Should find DeepPartial type alias');
+      assert.ok(deepPartial.generics.length > 0, 'DeepPartial should have generics');
+      assert.ok(
+        deepPartial.generics.includes('T'),
+        `Should have generic T, got: ${JSON.stringify(deepPartial.generics)}`
+      );
+    });
+  });
+
+  // ── Function parsing ──────────────────────────────────────────────────
+
+  describe('function extraction', () => {
+    it('extracts named function declarations', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const paginate = metadata.definitions.find(d => d.name === 'paginate' && d.type === 'function');
+      assert.ok(paginate, 'Should find paginate function');
+      assert.equal(paginate.exported, true, 'paginate should be exported');
+      assert.ok(paginate.params.length > 0, 'paginate should have params');
+    });
+
+    it('extracts arrow functions as variables', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const createId = metadata.definitions.find(d => d.name === 'createId');
+      assert.ok(createId, 'Should find createId');
+      assert.equal(createId.type, 'function', 'Arrow functions should be typed as function');
+      assert.equal(createId.arrow, true, 'Should be flagged as arrow function');
+      assert.equal(createId.exported, true, 'createId should be exported');
+    });
+
+    it('extracts constant variables', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_types.ts');
+
+      const defaultPageSize = metadata.definitions.find(d => d.name === 'DEFAULT_PAGE_SIZE');
+      assert.ok(defaultPageSize, 'Should find DEFAULT_PAGE_SIZE');
+      assert.equal(defaultPageSize.type, 'variable');
+      assert.equal(defaultPageSize.exported, true);
+    });
+  });
+
+  // ── Export parsing ────────────────────────────────────────────────────
+
+  describe('export extraction', () => {
+    it('marks exported definitions correctly', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      const orderService = metadata.definitions.find(d => d.name === 'OrderService');
+      assert.ok(orderService, 'Should find OrderService');
+      assert.equal(orderService.exported, true, 'OrderService should be exported');
+
+      const orderFilter = metadata.definitions.find(d => d.name === 'OrderFilter');
+      assert.ok(orderFilter, 'Should find OrderFilter');
+      assert.equal(orderFilter.exported, true, 'OrderFilter should be exported');
+
+      const orderStatus = metadata.definitions.find(d => d.name === 'OrderStatus');
+      assert.ok(orderStatus, 'Should find OrderStatus');
+      assert.equal(orderStatus.exported, true, 'OrderStatus should be exported');
+
+      const priority = metadata.definitions.find(d => d.name === 'Priority');
+      assert.ok(priority, 'Should find Priority');
+      assert.equal(priority.exported, true, 'Priority should be exported');
+    });
+  });
+
+  // ── Graceful null return ──────────────────────────────────────────────
+
+  describe('graceful handling', () => {
+    it('produces valid metadata with defines and references arrays', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      assert.ok(Array.isArray(metadata.defines), 'defines should be an array');
+      assert.ok(Array.isArray(metadata.references), 'references should be an array');
+      assert.ok(Array.isArray(metadata.imports), 'imports should be an array');
+      assert.ok(Array.isArray(metadata.scope), 'scope should be an array');
+      assert.ok(metadata.typeInfo, 'typeInfo should exist');
+    });
+  });
+
+  // ── Chunking ──────────────────────────────────────────────────────────
+
+  describe('chunking', () => {
+    it('produces chunks that respect class, interface, and function boundaries', () => {
+      const filePath = path.join(FIXTURES, 'sample_service.ts');
+      const content = fs.readFileSync(filePath, 'utf8');
+      const tree = analyzer.parse(filePath, content);
+      assert.ok(tree, 'Should parse sample_service.ts');
+
+      // Use a small maxSize to force multiple chunks
+      const chunks = analyzer.chunk(tree, content, { maxSize: 300 }, filePath);
+      assert.ok(chunks.length > 0, 'Should produce at least one chunk');
+
+      // Each chunk should have content, startLine, endLine, size
+      for (const chunk of chunks) {
+        assert.ok(typeof chunk.content === 'string', 'chunk.content should be a string');
+        assert.ok(typeof chunk.startLine === 'number', 'chunk.startLine should be a number');
+        assert.ok(typeof chunk.endLine === 'number', 'chunk.endLine should be a number');
+        assert.ok(typeof chunk.size === 'number', 'chunk.size should be a number');
+        assert.ok(chunk.size > 0, 'chunk.size should be > 0');
+      }
+
+      // With small maxSize, there should be multiple chunks
+      assert.ok(chunks.length > 1, 'Should produce multiple chunks with small maxSize');
+    });
+
+    it('keeps small files in a single chunk when within maxSize', () => {
+      const filePath = path.join(FIXTURES, 'sample_types.ts');
+      const content = fs.readFileSync(filePath, 'utf8');
+      const tree = analyzer.parse(filePath, content);
+      assert.ok(tree, 'Should parse sample_types.ts');
+
+      // Use a very large maxSize
+      const chunks = analyzer.chunk(tree, content, { maxSize: 100000 }, filePath);
+      // Everything should fit in very few chunks (possibly merged)
+      assert.ok(chunks.length >= 1, 'Should produce at least one chunk');
+    });
+  });
+
+  // ── Multiple top-level definitions ────────────────────────────────────
+
+  describe('multiple top-level definitions', () => {
+    it('extracts all top-level definitions from a file', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      // Should have: OrderFilter (interface), OrderStatus (type_alias),
+      // Priority (enum), OrderService (class)
+      const types = metadata.definitions.map(d => d.type);
+      assert.ok(types.includes('interface'), 'Should have an interface definition');
+      assert.ok(types.includes('type_alias'), 'Should have a type_alias definition');
+      assert.ok(types.includes('enum'), 'Should have an enum definition');
+      assert.ok(types.includes('class'), 'Should have a class definition');
+    });
+
+    it('lists all defines including methods in the top-level defines array', () => {
+      const { metadata } = analyzeFixture(analyzer, 'sample_service.ts');
+
+      // The defines array should include classes, interfaces, enums, type aliases,
+      // AND methods from classes
+      const defineNames = metadata.defines.map(d => d.name);
+      assert.ok(defineNames.includes('OrderService'), 'defines should include OrderService');
+      assert.ok(defineNames.includes('OrderFilter'), 'defines should include OrderFilter');
+      assert.ok(defineNames.includes('OrderStatus'), 'defines should include OrderStatus');
+      assert.ok(defineNames.includes('Priority'), 'defines should include Priority');
+      assert.ok(defineNames.includes('create'), 'defines should include create method');
+      assert.ok(defineNames.includes('validate'), 'defines should include validate method');
+    });
+  });
+});
+
+// ── Graceful null when tree-sitter unavailable ──────────────────────────────
+
+describe('TypeScriptAnalyzer without tree-sitter', { skip: treeSitterAvailable ? 'tree-sitter IS available; skipping unavailability test' : false }, () => {
+  it('returns null gracefully when tree-sitter-typescript unavailable', () => {
+    // When tree-sitter is not installed, loadParser returns null
+    // and parse() should return null
+    const { TypeScriptAnalyzer: TSAnalyzer } = require('../index');
+    const analyzer = new TSAnalyzer();
+    const result = analyzer.parse('test.ts', 'const x = 1;');
+    assert.equal(result, null, 'Should return null when tree-sitter is unavailable');
+  });
+});

--- a/analyzers/typescript/index.js
+++ b/analyzers/typescript/index.js
@@ -1,0 +1,1144 @@
+'use strict';
+
+const path = require('path');
+const { BaseAnalyzer } = require('../base-analyzer');
+const { loadParser, loadTSXParser } = require('../shared/tree-sitter-loader');
+
+/**
+ * TypeScript/TSX Analyzer
+ *
+ * Extracts semantic metadata from TypeScript and TSX files using tree-sitter.
+ * Handles classes, interfaces, type aliases, enums, functions, imports, exports,
+ * decorators, generics, and visibility modifiers.
+ */
+class TypeScriptAnalyzer extends BaseAnalyzer {
+  /**
+   * Parse TypeScript/TSX source code into a tree-sitter AST.
+   * Detects .tsx from filePath and uses the TSX parser accordingly.
+   * @param {string} filePath - Path to the file
+   * @param {string} content - Raw file content
+   * @returns {object|null} Parsed tree-sitter tree, or null if parsing fails
+   */
+  parse(filePath, content) {
+    const ext = path.extname(filePath).toLowerCase();
+    const loaded = ext === '.tsx' ? loadTSXParser() : loadParser('typescript');
+    if (!loaded) return null;
+
+    try {
+      return loaded.parser.parse(content);
+    } catch (err) {
+      console.warn(`[ts-analyzer] Failed to parse ${filePath}: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Extract semantic metadata from a parsed TypeScript AST.
+   * @param {object} tree - tree-sitter parse tree
+   * @param {string} filePath - Path for scope derivation
+   * @param {string} content - Raw source content
+   * @returns {object} Metadata object
+   */
+  extractMetadata(tree, filePath, content) {
+    const rootNode = tree.rootNode;
+    const imports = extractImports(rootNode, content);
+    const exports = extractExports(rootNode, content);
+    const scope = deriveScope(filePath);
+
+    const definitions = [];
+    const allDefines = [];
+    const allReferences = new Set();
+
+    // Walk top-level children
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+
+      // Handle export_statement wrapping declarations
+      const innerNode = unwrapExportStatement(node);
+      const isExported = node.type === 'export_statement' || hasExportKeyword(node, content);
+
+      switch (innerNode.type) {
+        case 'class_declaration': {
+          const cls = extractClass(innerNode, content, node);
+          cls.exported = cls.exported || isExported;
+          definitions.push(cls);
+          allDefines.push({ name: cls.name, type: 'class', exported: cls.exported });
+          if (cls.defines) {
+            for (const d of cls.defines) {
+              allDefines.push(d);
+            }
+          }
+          collectReferences(cls, allReferences);
+          break;
+        }
+        case 'abstract_class_declaration': {
+          const cls = extractClass(innerNode, content, node);
+          cls.exported = cls.exported || isExported;
+          cls.abstract = true;
+          if (cls.typeInfo) cls.typeInfo.abstract = true;
+          definitions.push(cls);
+          allDefines.push({ name: cls.name, type: 'class', exported: cls.exported });
+          if (cls.defines) {
+            for (const d of cls.defines) {
+              allDefines.push(d);
+            }
+          }
+          collectReferences(cls, allReferences);
+          break;
+        }
+        case 'interface_declaration': {
+          const iface = extractInterface(innerNode, content);
+          iface.exported = iface.exported || isExported;
+          definitions.push(iface);
+          allDefines.push({ name: iface.name, type: 'interface', exported: iface.exported });
+          collectReferences(iface, allReferences);
+          break;
+        }
+        case 'type_alias_declaration': {
+          const alias = extractTypeAlias(innerNode, content);
+          alias.exported = alias.exported || isExported;
+          definitions.push(alias);
+          allDefines.push({ name: alias.name, type: 'type_alias', exported: alias.exported });
+          collectReferences(alias, allReferences);
+          break;
+        }
+        case 'enum_declaration': {
+          const en = extractEnum(innerNode, content);
+          en.exported = en.exported || isExported;
+          definitions.push(en);
+          allDefines.push({ name: en.name, type: 'enum', exported: en.exported });
+          break;
+        }
+        case 'function_declaration': {
+          const fn = extractFunction(innerNode, content);
+          fn.exported = fn.exported || isExported;
+          definitions.push(fn);
+          allDefines.push({ name: fn.name, type: 'function', exported: fn.exported });
+          collectReferences(fn, allReferences);
+          break;
+        }
+        case 'lexical_declaration':
+        case 'variable_declaration': {
+          const vars = extractVariableDeclaration(innerNode, content, isExported);
+          for (const v of vars) {
+            definitions.push(v);
+            allDefines.push({ name: v.name, type: v.type, exported: v.exported });
+            collectReferences(v, allReferences);
+          }
+          break;
+        }
+        default:
+          // export_statement may contain re-exports without inner declaration
+          break;
+      }
+    }
+
+    // Collect import references
+    for (const imp of imports) {
+      allReferences.add(imp.name);
+    }
+
+    // Determine primary definition
+    const primary = definitions.find(d =>
+      d.type === 'class' || d.type === 'interface'
+    ) || definitions[0] || { type: 'module', name: path.basename(filePath, path.extname(filePath)) };
+
+    return {
+      type: primary.type,
+      name: primary.name,
+      exported: primary.exported || false,
+      inherits: primary.inherits || null,
+      scope,
+      defines: allDefines,
+      references: Array.from(allReferences),
+      imports,
+      exports,
+      definitions,
+      typeInfo: primary.typeInfo || {
+        interfaces_implemented: [],
+        generics: [],
+        decorators: [],
+        abstract: false,
+      },
+    };
+  }
+}
+
+// ─── Helper: Extract text from a tree-sitter node ───────────────────────────
+
+/**
+ * Get the source text of a tree-sitter node.
+ * @param {object} node - tree-sitter node
+ * @param {string} content - full source content
+ * @returns {string}
+ */
+function extractNodeText(node, content) {
+  if (!node) return '';
+  return content.slice(node.startIndex, node.endIndex).trim();
+}
+
+// ─── Helper: Derive scope from file path ────────────────────────────────────
+
+/**
+ * Derive a scope array from a file path.
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+function deriveScope(filePath) {
+  const parsed = path.parse(filePath);
+  const segments = parsed.dir.split(path.sep).filter(Boolean);
+  // Take the last few meaningful segments (skip root-level noise)
+  const srcIndex = segments.indexOf('src');
+  if (srcIndex >= 0) {
+    return segments.slice(srcIndex);
+  }
+  // If no 'src' dir, take the last 3 segments
+  return segments.slice(-3);
+}
+
+// ─── Helper: Unwrap export_statement to get inner declaration ───────────────
+
+/**
+ * If the node is an export_statement, return its inner declaration node.
+ * Otherwise return the node itself.
+ * @param {object} node
+ * @returns {object}
+ */
+function unwrapExportStatement(node) {
+  if (node.type === 'export_statement') {
+    // Look for the declaration child (class_declaration, function_declaration, etc.)
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (
+        child.type === 'class_declaration' ||
+        child.type === 'abstract_class_declaration' ||
+        child.type === 'interface_declaration' ||
+        child.type === 'type_alias_declaration' ||
+        child.type === 'enum_declaration' ||
+        child.type === 'function_declaration' ||
+        child.type === 'lexical_declaration' ||
+        child.type === 'variable_declaration'
+      ) {
+        return child;
+      }
+    }
+  }
+  return node;
+}
+
+// ─── Helper: Check for export keyword ───────────────────────────────────────
+
+/**
+ * Check if a node has an 'export' keyword as a direct child.
+ * @param {object} node
+ * @param {string} content
+ * @returns {boolean}
+ */
+function hasExportKeyword(node, content) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (extractNodeText(child, content) === 'export') {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ─── Imports ────────────────────────────────────────────────────────────────
+
+/**
+ * Extract all import statements from the root node.
+ * Differentiates regular imports from type imports.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{name: string, from: string, isType: boolean}>}
+ */
+function extractImports(rootNode, content) {
+  const imports = [];
+
+  for (let i = 0; i < rootNode.childCount; i++) {
+    const node = rootNode.child(i);
+    if (node.type !== 'import_statement') continue;
+
+    const text = extractNodeText(node, content);
+    const isTypeImport = text.startsWith('import type ');
+
+    // Extract the source (from clause)
+    const sourceNode = node.childForFieldName('source');
+    const from = sourceNode ? extractNodeText(sourceNode, content).replace(/['"]/g, '') : '';
+
+    // Extract imported names from import_clause
+    const importClause = findChildByType(node, 'import_clause');
+    if (importClause) {
+      extractImportNames(importClause, content, from, isTypeImport, imports);
+    }
+  }
+
+  return imports;
+}
+
+/**
+ * Recursively extract import names from an import_clause node.
+ * @param {object} node - import_clause or named_imports node
+ * @param {string} content
+ * @param {string} from - module path
+ * @param {boolean} isTypeImport - whether the entire import is a type import
+ * @param {Array} imports - accumulator array
+ */
+function extractImportNames(node, content, from, isTypeImport, imports) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+
+    if (child.type === 'identifier' || child.type === 'type_identifier') {
+      // Default import
+      imports.push({ name: extractNodeText(child, content), from, isType: isTypeImport });
+    } else if (child.type === 'named_imports') {
+      // Named imports: { X, Y, Z }
+      for (let j = 0; j < child.childCount; j++) {
+        const spec = child.child(j);
+        if (spec.type === 'import_specifier') {
+          const nameNode = spec.childForFieldName('name') || spec.childForFieldName('alias');
+          const name = nameNode ? extractNodeText(nameNode, content) : '';
+          if (name) {
+            // Check if individual specifier has 'type' keyword
+            const specText = extractNodeText(spec, content);
+            const specIsType = isTypeImport || specText.startsWith('type ');
+            imports.push({ name, from, isType: specIsType });
+          }
+        }
+      }
+    } else if (child.type === 'namespace_import') {
+      // import * as X
+      const nameNode = findChildByType(child, 'identifier');
+      if (nameNode) {
+        imports.push({ name: extractNodeText(nameNode, content), from, isType: isTypeImport });
+      }
+    }
+  }
+}
+
+// ─── Exports ────────────────────────────────────────────────────────────────
+
+/**
+ * Extract all export statements from the root node.
+ * @param {object} rootNode
+ * @param {string} content
+ * @returns {Array<{name: string, isDefault: boolean, isReExport: boolean, from: string|null}>}
+ */
+function extractExports(rootNode, content) {
+  const exports = [];
+
+  for (let i = 0; i < rootNode.childCount; i++) {
+    const node = rootNode.child(i);
+    if (node.type !== 'export_statement') continue;
+
+    const text = extractNodeText(node, content);
+    const isDefault = text.includes('export default');
+
+    // Check for re-export (export ... from '...')
+    const sourceNode = node.childForFieldName('source');
+    const from = sourceNode ? extractNodeText(sourceNode, content).replace(/['"]/g, '') : null;
+    const isReExport = from !== null;
+
+    // Get the inner declaration
+    const inner = unwrapExportStatement(node);
+
+    if (inner !== node) {
+      // Has a declaration
+      const nameNode = inner.childForFieldName('name');
+      const name = nameNode ? extractNodeText(nameNode, content) : '';
+      if (name) {
+        exports.push({ name, isDefault, isReExport, from });
+      }
+    } else {
+      // Named export clause: export { X, Y }
+      const exportClause = findChildByType(node, 'export_clause');
+      if (exportClause) {
+        for (let j = 0; j < exportClause.childCount; j++) {
+          const spec = exportClause.child(j);
+          if (spec.type === 'export_specifier') {
+            const nameNode = spec.childForFieldName('name');
+            const name = nameNode ? extractNodeText(nameNode, content) : '';
+            if (name) {
+              exports.push({ name, isDefault: name === 'default', isReExport, from });
+            }
+          }
+        }
+      } else if (isDefault) {
+        // export default <expression>
+        exports.push({ name: 'default', isDefault: true, isReExport, from });
+      }
+    }
+  }
+
+  return exports;
+}
+
+// ─── Class Extraction ───────────────────────────────────────────────────────
+
+/**
+ * Extract class information from a class_declaration or abstract_class_declaration node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractClass(node, content, parentNode) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+  const isAbstract = node.type === 'abstract_class_declaration';
+
+  // Heritage: extends and implements
+  let inherits = null;
+  const implementsList = [];
+  const heritage = findChildByType(node, 'class_heritage');
+  if (heritage) {
+    for (let i = 0; i < heritage.childCount; i++) {
+      const child = heritage.child(i);
+      if (child.type === 'extends_clause') {
+        const extendsValue = findChildByType(child, 'identifier') || findChildByType(child, 'type_identifier');
+        // Also check for generic type references inside extends
+        const genericRef = findChildByType(child, 'generic_type');
+        if (genericRef) {
+          const typeNameNode = findChildByType(genericRef, 'type_identifier') || findChildByType(genericRef, 'identifier');
+          inherits = typeNameNode ? extractNodeText(typeNameNode, content) : null;
+        } else if (extendsValue) {
+          inherits = extractNodeText(extendsValue, content);
+        }
+      } else if (child.type === 'implements_clause') {
+        for (let j = 0; j < child.childCount; j++) {
+          const impl = child.child(j);
+          if (impl.type === 'type_identifier' || impl.type === 'identifier') {
+            implementsList.push(extractNodeText(impl, content));
+          } else if (impl.type === 'generic_type') {
+            const typeNameNode = findChildByType(impl, 'type_identifier') || findChildByType(impl, 'identifier');
+            if (typeNameNode) {
+              implementsList.push(extractNodeText(typeNameNode, content));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Decorators
+  // Decorators: check both the node itself and the parent (export_statement may hold decorators)
+  let decorators = getDecorators(node, content);
+  if (decorators.length === 0 && parentNode && parentNode !== node) {
+    decorators = getDecorators(parentNode, content);
+  }
+
+  // Generics
+  const generics = getTypeParameters(node, content);
+
+  // Body: methods and fields
+  const body = findChildByType(node, 'class_body');
+  const defines = [];
+  const references = new Set();
+
+  if (body) {
+    for (let i = 0; i < body.childCount; i++) {
+      const member = body.child(i);
+
+      if (member.type === 'method_definition') {
+        const method = extractMethod(member, content);
+        defines.push(method);
+        // Collect type references from return type
+        if (method.returnType) {
+          extractTypeReferences(method.returnType, references);
+        }
+      } else if (member.type === 'abstract_method_signature') {
+        const method = extractAbstractMethod(member, content);
+        defines.push(method);
+        if (method.returnType) {
+          extractTypeReferences(method.returnType, references);
+        }
+      } else if (member.type === 'public_field_definition') {
+        const field = extractField(member, content);
+        defines.push(field);
+        if (field.fieldType) {
+          extractTypeReferences(field.fieldType, references);
+        }
+      }
+    }
+  }
+
+  // Collect references from inherits and implements
+  if (inherits) references.add(inherits);
+  for (const impl of implementsList) references.add(impl);
+
+  return {
+    type: 'class',
+    name,
+    exported: false,
+    inherits,
+    abstract: isAbstract,
+    defines,
+    references: Array.from(references),
+    typeInfo: {
+      interfaces_implemented: implementsList,
+      generics,
+      decorators,
+      abstract: isAbstract,
+    },
+  };
+}
+
+// ─── Method Extraction ──────────────────────────────────────────────────────
+
+/**
+ * Extract method information from a method_definition node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractMethod(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+  const visibility = getVisibility(node);
+  const isAsync = hasChildWithText(node, content, 'async');
+  const isAbstract = hasChildWithText(node, content, 'abstract');
+  const isStatic = hasChildWithText(node, content, 'static');
+  const returnType = getReturnType(node, content);
+  const params = extractParameters(node, content);
+  const decorators = getDecorators(node, content);
+
+  // Detect getter/setter
+  const fullText = extractNodeText(node, content);
+  const isGetter = fullText.startsWith('get ') || (nameNode && hasModifierBefore(node, content, 'get'));
+  const isSetter = fullText.startsWith('set ') || (nameNode && hasModifierBefore(node, content, 'set'));
+
+  const methodType = isGetter ? 'getter' : isSetter ? 'setter' : 'method';
+
+  const result = {
+    name,
+    type: methodType,
+    visibility,
+    async: isAsync,
+    static: isStatic,
+    abstract: isAbstract,
+    returnType,
+  };
+
+  if (params.length > 0) {
+    result.params = params;
+  }
+
+  if (decorators.length > 0) {
+    result.decorators = decorators;
+  }
+
+  return result;
+}
+
+// ─── Abstract Method Extraction ─────────────────────────────────────────────
+
+/**
+ * Extract abstract method signature from an abstract_method_signature node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractAbstractMethod(node, content) {
+  const nameNode = findChildByType(node, 'property_identifier');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+  const returnType = getReturnType(node, content);
+  const params = extractParameters(node, content);
+
+  const result = {
+    name,
+    type: 'method',
+    visibility: 'public',
+    async: false,
+    static: false,
+    abstract: true,
+    returnType,
+  };
+
+  if (params.length > 0) {
+    result.params = params;
+  }
+
+  return result;
+}
+
+// ─── Field Extraction ───────────────────────────────────────────────────────
+
+/**
+ * Extract field information from a public_field_definition node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractField(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+  const visibility = getVisibility(node);
+  const typeAnnotation = findChildByType(node, 'type_annotation');
+  const fieldType = typeAnnotation ? extractTypeAnnotationValue(typeAnnotation, content) : null;
+
+  const isReadonly = hasChildWithText(node, content, 'readonly');
+  const isStatic = hasChildWithText(node, content, 'static');
+
+  return {
+    name,
+    type: 'property',
+    visibility,
+    fieldType,
+    readonly: isReadonly,
+    static: isStatic,
+  };
+}
+
+// ─── Interface Extraction ───────────────────────────────────────────────────
+
+/**
+ * Extract interface information from an interface_declaration node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractInterface(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+
+  // Generics
+  const generics = getTypeParameters(node, content);
+
+  // Extends
+  const extendsList = [];
+  const extendsClause = findChildByType(node, 'extends_type_clause');
+  if (extendsClause) {
+    for (let i = 0; i < extendsClause.childCount; i++) {
+      const child = extendsClause.child(i);
+      if (child.type === 'type_identifier' || child.type === 'identifier') {
+        extendsList.push(extractNodeText(child, content));
+      } else if (child.type === 'generic_type') {
+        // e.g., Repository<Order>
+        const typeNameNode = findChildByType(child, 'type_identifier') || findChildByType(child, 'identifier');
+        if (typeNameNode) {
+          extendsList.push(extractNodeText(typeNameNode, content));
+        }
+      }
+    }
+  }
+
+  // Properties and method signatures
+  const properties = [];
+  const body = findChildByType(node, 'interface_body') || findChildByType(node, 'object_type');
+  if (body) {
+    for (let i = 0; i < body.childCount; i++) {
+      const member = body.child(i);
+
+      if (member.type === 'property_signature') {
+        const propName = member.childForFieldName('name');
+        const propNameStr = propName ? extractNodeText(propName, content) : '';
+        const typeAnnotation = findChildByType(member, 'type_annotation');
+        const propType = typeAnnotation ? extractTypeAnnotationValue(typeAnnotation, content) : null;
+        const isOptional = extractNodeText(member, content).includes('?');
+
+        properties.push({
+          name: propNameStr,
+          type: 'property',
+          propertyType: propType,
+          optional: isOptional,
+        });
+      } else if (member.type === 'method_signature') {
+        const methodName = member.childForFieldName('name');
+        const methodNameStr = methodName ? extractNodeText(methodName, content) : '';
+        const returnType = getReturnType(member, content);
+        const params = extractParameters(member, content);
+        const methodGenerics = getTypeParameters(member, content);
+
+        const methodDef = {
+          name: methodNameStr,
+          type: 'method',
+          returnType,
+        };
+
+        if (params.length > 0) {
+          methodDef.params = params;
+        }
+
+        if (methodGenerics.length > 0) {
+          methodDef.generics = methodGenerics;
+        }
+
+        properties.push(methodDef);
+      }
+    }
+  }
+
+  return {
+    type: 'interface',
+    name,
+    exported: false,
+    extends: extendsList,
+    properties,
+    generics,
+    references: [...extendsList],
+  };
+}
+
+// ─── Type Alias Extraction ──────────────────────────────────────────────────
+
+/**
+ * Extract type alias information from a type_alias_declaration node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractTypeAlias(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+
+  // Generics
+  const generics = getTypeParameters(node, content);
+
+  // The type value (everything after the = sign)
+  const valueNode = node.childForFieldName('value');
+  const definition = valueNode ? extractNodeText(valueNode, content) : '';
+
+  return {
+    type: 'type_alias',
+    name,
+    exported: false,
+    definition,
+    generics,
+    references: [],
+  };
+}
+
+// ─── Enum Extraction ────────────────────────────────────────────────────────
+
+/**
+ * Extract enum information from an enum_declaration node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractEnum(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+
+  const members = [];
+  const body = findChildByType(node, 'enum_body');
+  if (body) {
+    for (let i = 0; i < body.childCount; i++) {
+      const member = body.child(i);
+      if (member.type === 'enum_assignment') {
+        // enum_assignment has a property_identifier child (name) and a value child
+        const nameNode = findChildByType(member, 'property_identifier');
+        const memberName = nameNode ? extractNodeText(nameNode, content) : '';
+        // Value: find string or number literal after the = sign
+        let value = null;
+        for (let j = 0; j < member.childCount; j++) {
+          const child = member.child(j);
+          if (child.type === 'string') {
+            value = extractNodeText(child, content).replace(/['"]/g, '');
+          } else if (child.type === 'number') {
+            value = extractNodeText(child, content);
+          }
+        }
+        if (memberName) {
+          members.push({ name: memberName, value });
+        }
+      } else if (member.type === 'property_identifier') {
+        // Simple enum member without value assignment
+        const memberName = extractNodeText(member, content);
+        if (memberName && memberName !== '{' && memberName !== '}' && memberName !== ',') {
+          members.push({ name: memberName, value: null });
+        }
+      }
+    }
+  }
+
+  return {
+    type: 'enum',
+    name,
+    exported: false,
+    members,
+  };
+}
+
+// ─── Function Extraction ────────────────────────────────────────────────────
+
+/**
+ * Extract function information from a function_declaration node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {object}
+ */
+function extractFunction(node, content) {
+  const nameNode = node.childForFieldName('name');
+  const name = nameNode ? extractNodeText(nameNode, content) : '';
+  const isAsync = hasChildWithText(node, content, 'async');
+  const returnType = getReturnType(node, content);
+  const params = extractParameters(node, content);
+  const generics = getTypeParameters(node, content);
+
+  const references = new Set();
+  if (returnType) {
+    extractTypeReferences(returnType, references);
+  }
+  for (const p of params) {
+    if (p.type) {
+      extractTypeReferences(p.type, references);
+    }
+  }
+
+  return {
+    type: 'function',
+    name,
+    exported: false,
+    async: isAsync,
+    returnType,
+    params,
+    generics,
+    references: Array.from(references),
+  };
+}
+
+// ─── Variable / Arrow Function Extraction ───────────────────────────────────
+
+/**
+ * Extract variable declarations (const/let/var) which may contain arrow functions.
+ * @param {object} node - lexical_declaration or variable_declaration node
+ * @param {string} content
+ * @param {boolean} isExported
+ * @returns {Array<object>}
+ */
+function extractVariableDeclaration(node, content, isExported) {
+  const results = [];
+  const kind = extractNodeText(node.child(0), content); // const, let, var
+
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === 'variable_declarator') {
+      const nameNode = child.childForFieldName('name');
+      const name = nameNode ? extractNodeText(nameNode, content) : '';
+      const valueNode = child.childForFieldName('value');
+      const typeAnnotation = findChildByType(child, 'type_annotation');
+      const varType = typeAnnotation ? extractTypeAnnotationValue(typeAnnotation, content) : null;
+
+      if (valueNode && valueNode.type === 'arrow_function') {
+        // Arrow function: treat as a function definition
+        const isAsync = hasChildWithText(valueNode, content, 'async');
+        const returnType = getReturnType(valueNode, content);
+        const params = extractParameters(valueNode, content);
+        const generics = getTypeParameters(valueNode, content);
+
+        const references = new Set();
+        if (returnType) extractTypeReferences(returnType, references);
+        for (const p of params) {
+          if (p.type) extractTypeReferences(p.type, references);
+        }
+
+        results.push({
+          type: 'function',
+          name,
+          exported: isExported,
+          async: isAsync,
+          returnType,
+          params,
+          generics,
+          kind, // const, let
+          arrow: true,
+          references: Array.from(references),
+        });
+      } else {
+        // Regular variable
+        results.push({
+          type: 'variable',
+          name,
+          exported: isExported,
+          kind,
+          varType,
+          references: [],
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+// ─── Parameter Extraction ───────────────────────────────────────────────────
+
+/**
+ * Extract function/method parameters.
+ * @param {object} node - function_declaration, method_definition, arrow_function, or method_signature
+ * @param {string} content
+ * @returns {Array<{name: string, type: string|null, optional: boolean, rest: boolean}>}
+ */
+function extractParameters(node, content) {
+  const params = [];
+  const paramsNode = node.childForFieldName('parameters') || findChildByType(node, 'formal_parameters');
+
+  if (!paramsNode) return params;
+
+  for (let i = 0; i < paramsNode.childCount; i++) {
+    const param = paramsNode.child(i);
+
+    if (
+      param.type === 'required_parameter' ||
+      param.type === 'optional_parameter' ||
+      param.type === 'rest_parameter'
+    ) {
+      const patternNode = param.childForFieldName('pattern') || param.childForFieldName('name');
+      let paramName = '';
+
+      if (patternNode) {
+        paramName = extractNodeText(patternNode, content);
+      } else {
+        // Fallback: look for identifier
+        const ident = findChildByType(param, 'identifier');
+        if (ident) paramName = extractNodeText(ident, content);
+      }
+
+      // Skip visibility-prefixed constructor params: 'private readonly repo' => name is after modifiers
+      const fullParamText = extractNodeText(param, content);
+      const isAccessibilityParam = /^(public|private|protected|readonly)\s/.test(fullParamText);
+      if (isAccessibilityParam && !paramName) {
+        // Extract the actual parameter name from the text
+        const parts = fullParamText.split(/\s+/);
+        paramName = parts.filter(p => !['public', 'private', 'protected', 'readonly'].includes(p))[0] || '';
+        // Remove type annotation from the name
+        paramName = paramName.split(':')[0];
+      }
+
+      const typeAnnotation = findChildByType(param, 'type_annotation');
+      const paramType = typeAnnotation ? extractTypeAnnotationValue(typeAnnotation, content) : null;
+
+      const isOptional = param.type === 'optional_parameter';
+      const isRest = param.type === 'rest_parameter';
+
+      if (paramName && paramName !== '(' && paramName !== ')' && paramName !== ',') {
+        params.push({
+          name: paramName,
+          type: paramType,
+          optional: isOptional,
+          rest: isRest,
+        });
+      }
+    }
+  }
+
+  return params;
+}
+
+// ─── Visibility ─────────────────────────────────────────────────────────────
+
+/**
+ * Get the visibility modifier of a class member.
+ * @param {object} node - method_definition or public_field_definition
+ * @returns {string} 'public' | 'private' | 'protected'
+ */
+function getVisibility(node) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === 'accessibility_modifier') {
+      const text = child.text || '';
+      if (text === 'private') return 'private';
+      if (text === 'protected') return 'protected';
+      if (text === 'public') return 'public';
+    }
+  }
+  return 'public';
+}
+
+// ─── Return Type ────────────────────────────────────────────────────────────
+
+/**
+ * Get the return type annotation from a function/method node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {string|null}
+ */
+function getReturnType(node, content) {
+  const returnTypeNode = node.childForFieldName('return_type');
+  if (returnTypeNode) {
+    return extractTypeAnnotationValue(returnTypeNode, content);
+  }
+
+  // Fallback: look for type_annotation after the parameter list
+  const paramsNode = node.childForFieldName('parameters') || findChildByType(node, 'formal_parameters');
+  if (paramsNode) {
+    // The type annotation should be the sibling right after the params
+    let found = false;
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (found && child.type === 'type_annotation') {
+        return extractTypeAnnotationValue(child, content);
+      }
+      if (child === paramsNode) {
+        found = true;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract the type value from a type_annotation node (strips the leading colon).
+ * @param {object} typeAnnotation
+ * @param {string} content
+ * @returns {string}
+ */
+function extractTypeAnnotationValue(typeAnnotation, content) {
+  const text = extractNodeText(typeAnnotation, content);
+  // Remove leading ': ' if present
+  return text.startsWith(':') ? text.slice(1).trim() : text;
+}
+
+// ─── Type Parameters (Generics) ─────────────────────────────────────────────
+
+/**
+ * Get type parameters (generics) from a node.
+ * @param {object} node
+ * @param {string} content
+ * @returns {string[]}
+ */
+function getTypeParameters(node, content) {
+  const typeParams = node.childForFieldName('type_parameters') || findChildByType(node, 'type_parameters');
+  if (!typeParams) return [];
+
+  const params = [];
+  for (let i = 0; i < typeParams.childCount; i++) {
+    const child = typeParams.child(i);
+    if (child.type === 'type_parameter') {
+      const nameNode = child.childForFieldName('name') || findChildByType(child, 'type_identifier');
+      if (nameNode) {
+        params.push(extractNodeText(nameNode, content));
+      }
+    }
+  }
+
+  return params;
+}
+
+// ─── Decorators ─────────────────────────────────────────────────────────────
+
+/**
+ * Get decorator list from a node.
+ * Looks at previous siblings and direct children for decorator nodes.
+ * @param {object} node
+ * @param {string} content
+ * @returns {string[]}
+ */
+function getDecorators(node, content) {
+  const decorators = [];
+
+  // Check direct children
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === 'decorator') {
+      decorators.push(extractNodeText(child, content));
+    }
+  }
+
+  // Check preceding siblings (decorators are often siblings before the declaration)
+  let prev = node.previousSibling;
+  while (prev && prev.type === 'decorator') {
+    decorators.unshift(extractNodeText(prev, content));
+    prev = prev.previousSibling;
+  }
+
+  return decorators;
+}
+
+// ─── Utility Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Find the first child of a specific type.
+ * @param {object} node
+ * @param {string} type
+ * @returns {object|null}
+ */
+function findChildByType(node, type) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child.type === type) return child;
+  }
+  return null;
+}
+
+/**
+ * Check if a node has a child whose text matches a keyword.
+ * Only checks direct keyword/token children (not deep).
+ * @param {object} node
+ * @param {string} content
+ * @param {string} keyword
+ * @returns {boolean}
+ */
+function hasChildWithText(node, content, keyword) {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    const text = extractNodeText(child, content);
+    if (text === keyword) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if a modifier keyword appears before the name node.
+ * @param {object} node
+ * @param {string} content
+ * @param {string} modifier
+ * @returns {boolean}
+ */
+function hasModifierBefore(node, content, modifier) {
+  const nameNode = node.childForFieldName('name');
+  if (!nameNode) return false;
+
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child === nameNode) break;
+    if (extractNodeText(child, content) === modifier) return true;
+  }
+  return false;
+}
+
+/**
+ * Extract type references from a type string (simple heuristic).
+ * Pulls out PascalCase identifiers that look like type names.
+ * @param {string} typeStr
+ * @param {Set<string>} references
+ */
+function extractTypeReferences(typeStr, references) {
+  if (!typeStr) return;
+  // Match PascalCase identifiers (likely type names)
+  const matches = typeStr.match(/\b[A-Z][a-zA-Z0-9]*\b/g);
+  if (matches) {
+    for (const m of matches) {
+      // Skip common built-in types
+      if (!BUILTIN_TYPES.has(m)) {
+        references.add(m);
+      }
+    }
+  }
+}
+
+/** Built-in TypeScript types that should not be counted as references */
+const BUILTIN_TYPES = new Set([
+  'String', 'Number', 'Boolean', 'Object', 'Array', 'Promise',
+  'Record', 'Partial', 'Required', 'Readonly', 'Pick', 'Omit',
+  'Exclude', 'Extract', 'NonNullable', 'ReturnType', 'InstanceType',
+  'Map', 'Set', 'WeakMap', 'WeakSet', 'Date', 'Error', 'RegExp',
+  'Function', 'Symbol', 'BigInt', 'Uint8Array', 'Int32Array',
+]);
+
+/**
+ * Collect references from a definition object into a set.
+ * @param {object} def - a definition (class, interface, function, etc.)
+ * @param {Set<string>} references
+ */
+function collectReferences(def, references) {
+  if (def.references) {
+    for (const r of def.references) {
+      references.add(r);
+    }
+  }
+}
+
+module.exports = { TypeScriptAnalyzer };

--- a/docs/ANALYZER_GUIDE.md
+++ b/docs/ANALYZER_GUIDE.md
@@ -1,0 +1,314 @@
+# Analyzer Guide
+
+How to extend `src-to-kb` with custom language analyzers and framework enrichment layers.
+
+## Architecture Overview
+
+The analyzer system adds AST-aware chunking and semantic metadata to the knowledge base generation pipeline. When a file is processed, the system checks if an analyzer exists for that file's extension. If so, the file is parsed into an AST using tree-sitter, metadata is extracted, and chunks respect structural boundaries (classes, methods, functions). If no analyzer exists, the file falls back to the existing text-based chunking.
+
+```
+File (.rb, .ts, .dart, ...)
+  │
+  ▼
+Analyzer Registry (analyzers/index.js)
+  │
+  ├── Analyzer found? ──► Parse AST ──► Extract Metadata ──► Enrich (optional) ──► AST-aware Chunks
+  │                                                                                      │
+  └── No analyzer ──► Text-based Chunking (existing behavior)                            │
+                                                                                         ▼
+                                                                              Enriched Chunks with `ast` field
+```
+
+### Key Components
+
+- **`analyzers/index.js`** — Registry that maps file extensions to analyzer classes
+- **`analyzers/base-analyzer.js`** — Abstract base class all analyzers extend
+- **`analyzers/shared/tree-sitter-loader.js`** — Lazy-loads tree-sitter grammars with graceful fallback
+- **`analyzers/shared/chunk-splitter.js`** — AST-aware chunk splitting algorithm
+- **`analyzers/shared/metadata-schema.js`** — Validation for enriched chunk format
+- **`analyzers/<language>/index.js`** — Language-specific analyzer
+- **`analyzers/<language>/<framework>.js`** — Optional framework enrichment layer
+
+## How to Add a Language Analyzer
+
+### Step 1: Create the Analyzer Folder
+
+```
+analyzers/
+└── python/
+    ├── index.js              # PythonAnalyzer class
+    └── __tests__/
+        ├── python-analyzer.test.js
+        └── fixtures/
+            └── sample_class.py
+```
+
+### Step 2: Install the Tree-Sitter Grammar
+
+Add to `package.json`:
+
+```json
+{
+  "dependencies": {
+    "tree-sitter-python": "^0.23.x"
+  }
+}
+```
+
+### Step 3: Implement the Analyzer
+
+Create `analyzers/python/index.js`:
+
+```javascript
+'use strict';
+
+const { BaseAnalyzer } = require('../base-analyzer');
+const { loadParser } = require('../shared/tree-sitter-loader');
+
+class PythonAnalyzer extends BaseAnalyzer {
+  constructor() {
+    super();
+    this._parser = null;
+  }
+
+  parse(filePath, content) {
+    if (!this._parser) {
+      const loaded = loadParser('python');
+      if (!loaded) return null;
+      this._parser = loaded.parser;
+    }
+    try {
+      return this._parser.parse(content);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  extractMetadata(tree, filePath, content) {
+    const rootNode = tree.rootNode;
+    const scope = filePath.split('/').slice(0, -1).filter(s => s && s !== '.');
+
+    // Walk the AST and extract classes, functions, imports, etc.
+    const defines = [];
+    const references = [];
+    const imports = [];
+    let primaryType = 'module';
+    let primaryName = null;
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+      // Extract based on node.type:
+      // 'class_definition', 'function_definition', 'import_statement', etc.
+    }
+
+    return {
+      type: primaryType,
+      name: primaryName || filePath.split('/').pop().replace('.py', ''),
+      scope,
+      defines,
+      references,
+      imports,
+    };
+  }
+}
+
+module.exports = { PythonAnalyzer };
+```
+
+### Step 4: Register in the Extension Map
+
+Edit `analyzers/index.js` and add to `EXTENSION_MAP`:
+
+```javascript
+const EXTENSION_MAP = {
+  // ... existing entries
+  '.py': { analyzer: './python', enrichment: null },
+};
+```
+
+### Step 5: Add Tests
+
+Create `analyzers/python/__tests__/python-analyzer.test.js` using `node:test`:
+
+```javascript
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+
+let treeSitterAvailable = false;
+try {
+  require('tree-sitter');
+  require('tree-sitter-python');
+  treeSitterAvailable = true;
+} catch (err) {
+  console.warn('tree-sitter-python unavailable, skipping tests');
+}
+
+describe('PythonAnalyzer', { skip: !treeSitterAvailable }, () => {
+  // ... your tests
+});
+```
+
+## How to Add a Framework Enrichment
+
+Enrichment layers add framework-specific metadata on top of the base language analyzer output.
+
+### Step 1: Create the Enrichment File
+
+```
+analyzers/
+└── python/
+    ├── index.js
+    ├── django.js             # Django enrichment
+    └── __tests__/
+        ├── django-enrichment.test.js
+        └── fixtures/
+            └── sample_django_model.py
+```
+
+### Step 2: Implement the Enrichment
+
+Create `analyzers/python/django.js`:
+
+```javascript
+'use strict';
+
+/**
+ * Django enrichment layer for Python.
+ * Detects Django-specific patterns: models, views, URL configs, etc.
+ */
+
+/**
+ * @param {object} metadata - Base metadata from PythonAnalyzer
+ * @param {object} tree - tree-sitter parse tree
+ * @param {string} content - Raw file content
+ * @param {string} filePath - File path
+ * @returns {object} Enriched metadata with framework field
+ */
+function enrich(metadata, tree, content, filePath) {
+  // Detect Django model patterns
+  if (filePath.includes('models') && metadata.inherits === 'Model') {
+    metadata.framework = {
+      type: 'django_model',
+      fields: extractDjangoFields(tree, content),
+      meta: extractDjangoMeta(tree, content),
+    };
+  }
+
+  return metadata;
+}
+
+module.exports = { enrich };
+```
+
+### Step 3: Register with Auto-Detection
+
+In `analyzers/index.js`, update the `EXTENSION_MAP`:
+
+```javascript
+'.py': { analyzer: './python', enrichment: './python/django' },
+```
+
+Then add a detection function:
+
+```javascript
+function detectDjango(projectRoot) {
+  // Check for manage.py, settings.py, Django in requirements.txt
+}
+```
+
+The registry checks this before applying enrichment, so non-Django Python projects won't get Django-specific metadata.
+
+### Step 4: Document Detection Indicators
+
+The enrichment should only activate when the project matches the framework. Common indicators:
+
+- **Rails**: `Gemfile` with `gem 'rails'`, `config/routes.rb`, `app/models/`
+- **Flutter**: `pubspec.yaml` with `flutter:`, `package:flutter/` imports
+- **Django**: `manage.py`, `settings.py`, `django` in `requirements.txt`
+- **NestJS**: `@nestjs/core` in `package.json`, decorators like `@Module`
+
+## Enriched Chunk Format
+
+Base chunk fields (always present):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Chunk identifier (`doc_xxx_chunk_0`) |
+| `index` | number | Chunk index within the document |
+| `content` | string | Raw text content of the chunk |
+| `startLine` | number | Start line number |
+| `endLine` | number | End line number |
+| `size` | number | Content size in characters |
+
+AST metadata fields (added when an analyzer processes the file):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ast.type` | string | Primary structure type (`class`, `module`, `interface`, `mixin`, `extension`, `enum`, `function`) |
+| `ast.name` | string | Name of the primary structure |
+| `ast.inherits` | string\|null | Parent class/superclass |
+| `ast.exported` | boolean | Whether the definition is exported (TS/Dart) |
+| `ast.scope` | string[] | Path segments indicating code location |
+| `ast.defines` | object[] | List of definitions (classes, methods, fields, etc.) |
+| `ast.references` | string[] | Referenced types/classes |
+| `ast.imports` | object[] | Import statements |
+| `ast.framework` | object\|null | Framework-specific metadata |
+
+### `defines` Entry Format
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Definition name |
+| `type` | string | `class`, `method`, `field`, `constructor`, `interface`, `type_alias`, `enum` |
+| `visibility` | string | `public`, `private`, `protected` (language-specific) |
+| `async` | boolean | Whether the method is async |
+| `returnType` | string | Return type annotation (TS/Dart) |
+| `exported` | boolean | Whether exported (TS) |
+| `static` | boolean | Whether static |
+
+## Testing Guide
+
+Tests use Node.js built-in test runner (`node:test`). Run with:
+
+```bash
+# Run all analyzer tests
+node --test analyzers/*/__tests__/*.test.js
+
+# Run a specific analyzer's tests
+node --test analyzers/ruby/__tests__/*.test.js
+```
+
+All test files must gracefully skip when their tree-sitter grammar is unavailable:
+
+```javascript
+let treeSitterAvailable = false;
+try {
+  require('tree-sitter');
+  require('tree-sitter-<language>');
+  treeSitterAvailable = true;
+} catch (err) {
+  console.warn('Skipping tests: ' + err.message);
+}
+
+describe('MyAnalyzer', { skip: !treeSitterAvailable }, () => {
+  // tests here
+});
+```
+
+### Test Fixture Guidelines
+
+- Place fixtures in `analyzers/<language>/__tests__/fixtures/`
+- Use realistic but minimal code — each fixture should test specific patterns
+- Name fixtures descriptively: `sample_model.rb`, `sample_controller.rb`
+- Include comments in fixtures explaining what patterns they test
+
+## Future: Linker System
+
+A cross-codebase linker system is planned for a future phase. When writing analyzers, extract endpoint/API call information when relevant:
+
+- **REST endpoints**: HTTP method, path, controller action
+- **API calls**: client method, URL path, request/response types
+- **Event handlers**: event names, handler methods
+- **Database queries**: model references, association targets
+
+This data will be used by the linker to connect API definitions with their consumers across the codebase.

--- a/kb-generator.js
+++ b/kb-generator.js
@@ -7,6 +7,7 @@ const { EventEmitter } = require('events');
 const { ExternalServerService } = require('./external-server-service');
 const { isExternalServerEnabled } = require('./external-server-config');
 const { validateOpenAIKey: validateOpenAIKeyUtil, validateExternalServer: validateExternalServerUtil } = require('./validation-utils');
+const { getAnalyzer, getAnalyzerStats } = require('./analyzers');
 
 class KnowledgeBaseGenerator extends EventEmitter {
   constructor(config = {}) {
@@ -78,6 +79,9 @@ class KnowledgeBaseGenerator extends EventEmitter {
 
   async processRepository(repoPath, options = {}) {
     console.log(`\n🔍 Processing repository: ${repoPath}\n`);
+
+    // Store repo path for analyzer framework detection
+    this._repoPath = path.resolve(repoPath);
 
     if (!fs.existsSync(repoPath)) {
       throw new Error(`Repository path does not exist: ${repoPath}`);
@@ -325,8 +329,52 @@ class KnowledgeBaseGenerator extends EventEmitter {
     // Clean content
     const cleanedContent = this.cleanContent(document.content, document.metadata.type);
 
-    // Create chunks
-    document.chunks = this.createChunks(cleanedContent, document.id);
+    // Try AST-aware chunking if an analyzer is available
+    let astUsed = false;
+    const ext = path.extname(document.path);
+    const analyzer = getAnalyzer(ext, this._repoPath);
+
+    if (analyzer) {
+      try {
+        const tree = analyzer.parse(document.path, document.content);
+        if (tree) {
+          const metadata = analyzer.extractMetadata(tree, document.relativePath, document.content);
+          const enrichedMetadata = analyzer.enrich(metadata, tree, document.content, document.relativePath);
+          const astChunks = analyzer.chunk(tree, document.content, {
+            maxSize: this.config.chunkSize,
+            overlap: this.config.chunkOverlap,
+          }, document.relativePath);
+
+          // Build enriched chunks with IDs and ast metadata
+          document.chunks = astChunks.map((chunk, index) => ({
+            id: `${document.id}_chunk_${index}`,
+            index,
+            content: chunk.content,
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            size: chunk.size,
+            ...(chunk.context ? { context: chunk.context } : {}),
+            ast: enrichedMetadata,
+          }));
+
+          astUsed = true;
+          if (!this.stats.analyzerStats) {
+            this.stats.analyzerStats = { filesWithAST: 0, filesWithTextFallback: 0, analyzersUsed: new Set(), enrichmentsApplied: new Set() };
+          }
+          this.stats.analyzerStats.filesWithAST++;
+        }
+      } catch (err) {
+        console.warn(`⚠️  AST parsing failed for ${document.relativePath}, falling back to text chunking: ${err.message}`);
+      }
+    }
+
+    if (!astUsed) {
+      // Fallback: existing text-based chunking
+      document.chunks = this.createChunks(cleanedContent, document.id);
+      if (this.stats.analyzerStats) {
+        this.stats.analyzerStats.filesWithTextFallback++;
+      }
+    }
 
     // Generate embeddings if configured
     if (this.config.generateEmbeddings && this.config.openaiApiKey) {
@@ -487,9 +535,18 @@ class KnowledgeBaseGenerator extends EventEmitter {
   async saveMetadata() {
     const metadataPath = path.join(this.config.outputPath, 'metadata', 'summary.json');
 
+    // Finalize analyzer stats for serialization (convert Sets to arrays)
+    const analyzerStats = this.stats.analyzerStats
+      ? {
+          filesWithAST: this.stats.analyzerStats.filesWithAST,
+          filesWithTextFallback: this.stats.analyzerStats.filesWithTextFallback,
+          ...getAnalyzerStats(),
+        }
+      : undefined;
+
     const summary = {
       generatedAt: new Date().toISOString(),
-      stats: this.stats,
+      stats: { ...this.stats, analyzerStats },
       config: {
         chunkSize: this.config.chunkSize,
         chunkOverlap: this.config.chunkOverlap,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vezlo/src-to-kb",
-  "version": "1.3.4",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vezlo/src-to-kb",
-      "version": "1.3.4",
+      "version": "1.5.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0",
@@ -28,10 +28,17 @@
         "src-to-kb-api": "api-server.js",
         "src-to-kb-mcp": "mcp-server.mjs",
         "src-to-kb-mcp-install": "install-mcp.js",
-        "src-to-kb-search": "search.js"
+        "src-to-kb-search": "search.js",
+        "src-to-kb-upload": "upload.js"
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-dart": "^0.0.3",
+        "tree-sitter-ruby": "^0.23.1",
+        "tree-sitter-typescript": "^0.23.2"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -176,35 +183,27 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -825,9 +824,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -908,9 +907,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1059,6 +1058,28 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1159,9 +1180,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1459,6 +1480,82 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-dart": {
+      "optional": true
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-ruby": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.23.1.tgz",
+      "integrity": "sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1495,9 +1592,9 @@
       "license": "MIT"
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
   "scripts": {
     "start": "node kb-generator.js",
     "test": "node scripts/test.js",
+    "test:analyzers": "node --test analyzers/*/__tests__/*.test.js",
     "example": "node kb-generator.js ../SaaSBot --output ./test-output",
     "search": "node search.js",
     "mcp": "node mcp-server.mjs",
     "api": "node api-server.js",
-    "api:dev": "PORT=3000 API_KEY=dev-key nodemon api-server.js",
+    "api:dev": "PORT=3001 API_KEY=dev-key nodemon api-server.js",
     "publish-package": "./scripts/publish.sh",
     "prepublishOnly": "npm test"
   },
@@ -64,6 +65,12 @@
     "multer": "^2.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
+  },
+  "optionalDependencies": {
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-ruby": "^0.23.1",
+    "tree-sitter-typescript": "^0.23.2",
+    "tree-sitter-dart": "^0.0.3"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Add AST-aware chunking and semantic metadata extraction to the KB generation pipeline. When an analyzer exists for a file extension, code is parsed into an AST using tree-sitter, metadata is extracted (classes, methods, imports, references), and chunks respect structural boundaries. Files without a matching analyzer fall back to text-based chunking.

Language analyzers:
- Ruby: classes, modules, methods, visibility, includes/extends, attr_accessors, constants. Rails enrichment layer detects models (associations, validations, scopes, callbacks, enums), controllers (filters, strong params, rescue), routes (full endpoint expansion), and concerns.
- TypeScript/TSX: classes (abstract), interfaces, type aliases, enums, functions, imports/exports, decorators, generics, visibility modifiers.
- Dart: classes, mixins, extensions, enums, constructors, fields, imports. Flutter enrichment detects widgets (Stateless/Stateful), BLoC patterns, models (JSON/Freezed/Equatable), and navigation routes.

Shared infrastructure:
- tree-sitter-loader: lazy grammar loading with graceful fallback
- chunk-splitter: AST-aware splitting that respects code structure
- metadata-schema: validation for enriched chunk format
- base-analyzer: abstract class all analyzers extend
- analyzer registry: maps extensions to analyzers with framework detection (Rails, Flutter)

Integration:
- kb-generator.js tries AST pipeline first, falls back to text chunking
- summary.json includes analyzerStats (filesWithAST, textFallback)
- tree-sitter grammars are optionalDependencies — native compilation failures are handled gracefully

Tests: 118 passing across Ruby (54), TypeScript (29), Dart (20), and integration (15) test suites. All tests skip gracefully when tree-sitter grammars are unavailable.